### PR TITLE
Upgrade Lodash to address CVE-2018-16487

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,10 +3385,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "loglevel": {
       "version": "1.6.1",


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-16487. I think this shouldn’t actually affect the usage of Lodash here (from webpack-dev-server), but it's buried deep enough that I'm not really sure. Better to be safe and upgrade.