### PR TITLE
General Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
         width: 100%;
         height: 100%;
         z-index: 1;
-        white-space: pre;
+        white-space: pre-wrap;
       }
     </style>
   </head>

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import unified from 'unified';
 const processor = unified()
   .use(parse)
   .use(fixGoogleHtml)
-  // .use(require('./lib/log-tree'))
+  // .use(require('./lib/log-tree').default)
   .use(rehype2remarkWithSpaces)
   .use(stringify);
 

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -3,8 +3,53 @@
 import hast from 'hastscript';
 import visit from 'unist-util-visit';
 
+const blockElements = new Set([
+  'address',
+  'article',
+  'aside',
+  'blockquote',
+  'caption',
+  'center',  // historic
+  'dd',
+  'details',
+  'dialog',
+  'dir',  // historic
+  'div',
+  'dl',
+  'dt',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'frameset',  // historic
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hgroup',
+  'hr',
+  'isindex',  // historic
+  'li',
+  'main',
+  'menu',
+  'nav',
+  'noframes',  // historic
+  'ol',
+  'p',
+  'pre',
+  'section',
+  'summary',
+  'table',
+  'ul'
+]);
+
 const isList = node => node.tagName === 'ul' || node.tagName === 'ol';
 const isStyled = node => node.type === 'element' && node.properties.style;
+const isBlock = node => blockElements.has(node.tagName);
 
 // Wrap the children of `node` with the `wrapper` node.
 function wrapChildren (node, wrapper) {
@@ -74,6 +119,21 @@ export function unInlineStyles (node) {
   });
 }
 
+export function removeLineBreaksBeforeBlocks (node) {
+  const children = node.children;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (child.tagName === 'br' && isBlock(children[i + 1])) {
+      children.splice(i, 1);
+      i -= 1;
+    }
+    else if (child.children) {
+      removeLineBreaksBeforeBlocks(child);
+    }
+  }
+  node.children = children;
+}
+
 /**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
@@ -83,6 +143,7 @@ export default function fixGoogleHtml () {
   return (tree, file) => {
     unInlineStyles(tree);
     fixNestedLists(tree);
+    removeLineBreaksBeforeBlocks(tree);
     return tree;
   };
 }

--- a/lib/log-tree.js
+++ b/lib/log-tree.js
@@ -5,7 +5,7 @@ export default function logTree () {
   function logNode (node, indent = 0) {
     let name = `(${node.type})`;
     if (node.type === 'text') {
-      name = `${name}: ${node.value}`;
+      name = `${name}: \`${node.value}\``;
     }
     else if (node.type === 'element') {
       name = `<${node.tagName}>`;

--- a/lib/rehype-to-remark-with-spaces.js
+++ b/lib/rehype-to-remark-with-spaces.js
@@ -12,7 +12,12 @@ export default function rehype2remarkWithSpaces () {
   
   function preserveInitialSpaces (node) {
     if (node.type === 'text' && node.value.startsWith(' ')) {
-      node.value = spaceToken + node.value.slice(1);
+      if (node.value.startsWith(' ')) {
+        node.value = spaceToken + node.value.slice(1);
+      }
+      if (node.value.endsWith(' ')) {
+        node.value = node.value.slice(0, -1) + spaceToken;
+      }
     }
     if (node.children) {
       node.children.forEach(preserveInitialSpaces);


### PR DESCRIPTION
This fixes a bunch of small bugs I noticed while updating #6:

- Logging module now puts quotes around text so you can see whitespace at the end of a value.
- Wrap text in the output area so it’s actually readable.
- Make sure space at the *end* of text tokens is preserved. (We only did this at the start before, which was making a few critical errors.
- Remove excess space around paragraphs, headings, lists, and other blocks. Google Docs throws line breaks in between those items, and the markdown conversion turns both the line break AND the block element into line breaks, resulting in doubled-up breaks all over the place.