### PR TITLE
Remove excess whitespace at the start of list items.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const processor = unified()
   .use(fixGoogleHtml)
   // .use(require('./lib/log-tree').default)
   .use(rehype2remarkWithSpaces)
-  .use(stringify);
+  .use(stringify, {listItemIndent: '1'});
 
 function convertToMarkdown (html) {
   return processor.process(inputElement.innerHTML).then(String);


### PR DESCRIPTION
Fixes #2, depends on #7.