### PR TITLE
Support multiple lines in table cells

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import fixGoogleHtml from './lib/fix-google-html';
+import handlers from './lib/custom-converters';
 // rehype-dom-parse is a lightweight version of rehype-parse that leverages
 // browser APIs -- reduces bundle size by ~200 kB!
 // const parse = require('rehype-dom-parse').default;
@@ -12,7 +13,7 @@ const processor = unified()
   .use(parse)
   .use(fixGoogleHtml)
   // .use(require('./lib/log-tree').default)
-  .use(rehype2remarkWithSpaces)
+  .use(rehype2remarkWithSpaces, null, {handlers})
   .use(stringify, {listItemIndent: '1'});
 
 function convertToMarkdown (html) {

--- a/lib/custom-converters.js
+++ b/lib/custom-converters.js
@@ -1,0 +1,57 @@
+const all = require('hast-util-to-mdast/lib/all');
+
+/**
+ * @typedef {{type: string, children: Array<UnistNode>}} UnistNode
+ */
+
+/**
+ * @typedef {(node: UnistNode, type: string, props: any, children: Array<UnistNode>) => UnistNode} NodeBuilder
+ */
+
+/**
+ * Convert a Rehype table cell node to an MDast table cell node, using HTML
+ * nodes to represent multiline/block content inside the cell (since plain
+ * Markdown can only support inline/phrasing content in cells).
+ * 
+ * This is basically a customization of:
+ * https://github.com/syntax-tree/hast-util-to-mdast/blob/master/lib/handlers/table-cell.js
+ * 
+ * @param {NodeBuilder} h Creates a new mdast node
+ * @param {UnistNode} node The original rehype node to convert
+ */
+export function convertTableCell (h, node) {
+  let children = all(h, node);
+
+  // If there is more than one child and any of them are multiline/block
+  // objects, find a way to represent them (Markdown only support inline
+  // content in table cells).
+  // TODO: handle more than just paragraphs and line breaks? (lists, etc.)
+  // TODO: technically block elements could be deeply nested, but this
+  // implementation doesn't handle that. It's unlikely to occur in Google Docs.
+  if (children.length > 1) {
+    let newChildren = [];
+    for (let i = 0, len = children.length; i < len; i++) {
+      const child = children[i];
+      if (child.type === 'break') {
+        newChildren.push({type: 'html', value: '<br>'});
+      }
+      else if (child.type === 'paragraph') {
+        // Instead of using `<p>` elements, keep the resulting markup as simple
+        // as possible by just inserting `<br>` elements between paragraphs.
+        if (i > 0) newChildren.push({type: 'html', value: '<br>'});
+        newChildren.push(...child.children);
+      }
+      else {
+        newChildren.push(child);
+      }
+    }
+    children = newChildren;
+  }
+
+  return h(node, 'tableCell', children)
+}
+
+export default {
+  td: convertTableCell,
+  th: convertTableCell
+};


### PR DESCRIPTION
Plain Markdown syntax doesn't support more than one line in a table cell, but Google Docs lets you have many paragraphs or lines in each cell. This update supports multiple lines by adding a custom handler for table cell nodes which outputs MDast `html` nodes representing `<br>` tags to use in the table.

It converts paragraphs to inline text separated by `<br>` tags rather than actual `<p>` tags so as to keep the amount of inserted HTML fairly light. I think this is probably the right thing, but we’ll see if anyone has issues with it!

This is probably not the nicest implementation, but it works reasonably well with a few test cases. @wooorm’s latest comment (https://github.com/Mr0grog/google-docs-to-markdown/issues/10#issuecomment-595666863) suggests the right spot for this kind of logic is in the rehype → mdast conversion rather than in stringification, so that’s what I’ve done here. If `hast-util-to-mdast` gets more complicated and handles content in table cells differently in the future, this part *may* have to change, but I think that’s probably OK.

Fixes #10.