### PR TITLE
Fix incorrect license identifier in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Rob Brackett <rob@robbrackett.com>",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "dependencies": {},
   "devDependencies": {
     "copy-webpack-plugin": "^5.1.1",


### PR DESCRIPTION
`package.json` was listing the incorrect license (it’s correct everywhere else in the codebase).

Fixes #17.