### PR TITLE
Fix support for nested bold/italic formatting

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { h as hast } from 'hastscript';
-import { visit } from 'unist-util-visit';
+import { CONTINUE, EXIT, visit } from 'unist-util-visit';
 
 const blockElements = new Set([
   'address',
@@ -47,9 +47,20 @@ const blockElements = new Set([
   'ul'
 ]);
 
+// These elements convert to Markdown nodes that can't start or end with spaces.
+// For example, you can't start emphasis with a space: `This * is emphasized*`.
+const spaceSensitiveElements = new Set([
+  'em',
+  'strong',
+]);
+
 const isList = node => node.tagName === 'ul' || node.tagName === 'ol';
 const isStyled = node => node.type === 'element' && node.properties.style;
 const isBlock = node => node && blockElements.has(node.tagName);
+const isSpaceSensitive = node => node && spaceSensitiveElements.has(node.tagName);
+
+const spaceAtStartPattern = /^(\s+)/;
+const spaceAtEndPattern = /(\s+)$/;
 
 // Wrap the children of `node` with the `wrapper` node.
 function wrapChildren (node, wrapper) {
@@ -140,6 +151,90 @@ export function removeLineBreaksBeforeBlocks (node) {
 }
 
 /**
+ * Remove spaces from the start or end of nodes where it's not valid in Markdown
+ * (e.g. `<em>`) and return the removed spaces. Works recursively to handle
+ * nested nodes with surrounding spaces.
+ * @param {RehypeNode} node
+ * @returns {string}
+ */
+function _extractInvalidSpace (node, side = 'start') {
+  let totalSpace = '';
+
+  const reverse = side === 'start' ? false : true;
+  visit(node, (child, index, parent) => {
+    if (child.type === 'text') {
+      const pattern = side === 'start' ? spaceAtStartPattern : spaceAtEndPattern;
+      const spaceMatch = child.value.match(pattern);
+      if (spaceMatch) {
+        const space = spaceMatch[1];
+        const body = side === 'start'
+          ? child.value.slice(space.length)
+          : child.value.slice(0, -space.length);
+        totalSpace = side === 'start'
+          ? (totalSpace + space)
+          : (space + totalSpace);
+        if (body.length) {
+          child.value = body;
+          return EXIT;
+        }
+        else {
+          parent.children.splice(index, 1);
+          return side === 'start' ? index : index - 1;
+        }
+      }
+      else {
+        return EXIT;
+      }
+    }
+    else if (isSpaceSensitive(child)) {
+      return CONTINUE;
+    }
+    else {
+      return EXIT;
+    }
+  }, reverse);
+
+  return totalSpace;
+}
+
+/**
+ * In Google Docs (and HTML in general), an element that formats some text can
+ * start with spaces, tabs, etc. However, in Markdown, some inline markup
+ * (mainly emphasis marks like `**bold**` and `_italic_`) can't start or end
+ * with spaces. This finds such elements and moves leading and trailing spaces
+ * from inside to outside them.
+ * 
+ * For example, this turns a tree like:
+ * 
+ *     <p>Hello<em> italics </em></p>
+ * 
+ * Into:
+ * 
+ *     <p>Hello <em>italics</em> </p>
+ * 
+ * @param {RehypeNode} node Fix the tree below this node
+ */
+export function moveSpaceOutsideSensitiveChildren (node) {
+  visit(node, isSpaceSensitive, (node, index, parent) => {
+    let nextIndex = index + 1;
+
+    const startSpace = _extractInvalidSpace(node, 'start');
+    if (startSpace) {
+      parent.children.splice(index, 0, { type: 'text', value: startSpace });
+      nextIndex++;
+    }
+
+    const endSpace = _extractInvalidSpace(node, 'end');
+    if (endSpace) {
+      parent.children.splice(nextIndex, 0, { type: 'text', value: endSpace });
+      nextIndex++;
+    }
+
+    return nextIndex;
+  });
+}
+
+/**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
  * might apply there, too; I haven’t looked into it).
@@ -147,6 +242,7 @@ export function removeLineBreaksBeforeBlocks (node) {
 export default function fixGoogleHtml () {
   return (tree, file) => {
     unInlineStyles(tree);
+    moveSpaceOutsideSensitiveChildren(tree);
     fixNestedLists(tree);
     removeLineBreaksBeforeBlocks(tree);
     return tree;


### PR DESCRIPTION
I'm pretty sure nested bold and italic used to work before, but it seems to have regressed at some point (I ran into this while working on #52). This makes them work (again?).

It’s a little complex because it has to account for some funky cases around spaces at the start or end of some kinds of markup.