### PR TITLE
Fix support for non-paragraph line breaks

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -135,6 +135,48 @@ export function unInlineStyles (node) {
   });
 }
 
+/**
+ * Line breaks frequently wind up wrapped with a somewhat pointless `<span>`
+ * element that makes them hard to deal correctly with. Unwrap those line breaks
+ * so that they are bare `<br>` elements.
+ * 
+ * Changes this:
+ *     <span><br></span>
+ * To:
+ *     <br>
+ * @param {RehypeNode} node Fix the tree below this node
+ */
+export function unwrapLineBreaks (node) {
+  const children = node.children;
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (
+      child.tagName === 'span'
+      && child.children.length === 1
+      && child.children[0].tagName === 'br'
+    ) {
+      children.splice(i, 1, child.children[0]);
+    }
+    else if (child.children) {
+      unwrapLineBreaks(child);
+    }
+  }
+  node.children = children;
+}
+
+/**
+ * Paragraphs and other block elements frequently wind up preceded with
+ * pointless `<br>` elements. This is probably because paragraphs do not, by
+ * default, have any space around them in a Google doc, even though having a
+ * blank line is what causes Google Docs to spit out `<p>` elements instead of
+ * just `<br>` elements. 
+ * 
+ * Changes this:
+ *     <br><p>Blah</p>
+ * To:
+ *     <p>Blah</p>
+ * @param {RehypeNode} node Fix the tree below this node
+ */
 export function removeLineBreaksBeforeBlocks (node) {
   const children = node.children;
   for (let i = 0; i < children.length; i++) {
@@ -244,6 +286,7 @@ export default function fixGoogleHtml () {
     unInlineStyles(tree);
     moveSpaceOutsideSensitiveChildren(tree);
     fixNestedLists(tree);
+    unwrapLineBreaks(tree);
     removeLineBreaksBeforeBlocks(tree);
     return tree;
   };


### PR DESCRIPTION
Somewhere along the line, support for hard line breaks inside paragraphs, list items, etc. broke. Found while working on #52.