### PR TITLE
Support stike-through formatting

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -132,6 +132,11 @@ export function unInlineStyles (node) {
     } else if (/vertical-align:\s*sub/.test(style)) {
       wrapChildren(node, hast('sub'));
     }
+    // Some browsers paste with the `text-decoration` property and some use the
+    // newer `text-decoration-line`, so we need to support both.
+    if (/text-decoration(-line)?:\s*line-through/.test(style)) {
+      wrapChildren(node, hast('del'));
+    }
   });
 }
 


### PR DESCRIPTION
I thought this supported struck out text before, but apparently not. Found while working on #52.