### PR TITLE
Support table column alignment

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -58,6 +58,7 @@ const isList = node => node.tagName === 'ul' || node.tagName === 'ol';
 const isStyled = node => node.type === 'element' && node.properties.style;
 const isBlock = node => node && blockElements.has(node.tagName);
 const isSpaceSensitive = node => node && spaceSensitiveElements.has(node.tagName);
+const isCell = (node) => node.tagName === 'th' || node.tagName === 'td';
 
 const spaceAtStartPattern = /^(\s+)/;
 const spaceAtEndPattern = /(\s+)$/;
@@ -282,6 +283,50 @@ export function moveSpaceOutsideSensitiveChildren (node) {
 }
 
 /**
+ * @param {RehypeNode} node
+ * @returns {string|null}
+ */
+function getNodeTextAlignment (node) {
+  const style = node.properties.style;
+  const alignMatch = style?.match(/text-align:\s*(left|center|right)/);
+  if (alignMatch) {
+    return alignMatch[1];
+  }
+  return null;
+}
+
+/**
+ * Tables in Google Docs don't actually put alignment info on the columns or
+ * cells. Instead, cells have paragraphs that are aligned. This detects the
+ * alignment of the content of table cells so that the Markdown conversion will
+ * set the correct alignment for columns.
+ * @param {RehypeNode} node Fix the tree below this node
+ */
+export function detectTableColumnAlignment(node) {
+  visit(node, isCell, (node, _index, _parent) => {
+    if (!node.properties.align) {
+      let alignment = getNodeTextAlignment(node);
+      if (!alignment && node.children) {
+        for (let i = 0; i < node.children.length; i++) {
+          const childAlignment = getNodeTextAlignment(node.children[i]);
+          if (i === 0) {
+            alignment = childAlignment;
+          }
+          else if (childAlignment !== alignment) {
+            alignment = null;
+            break;
+          }
+        }
+      }
+
+      if (alignment) {
+        node.properties.align = alignment;
+      }
+    }
+  });
+}
+
+/**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
  * might apply there, too; I haven’t looked into it).
@@ -291,6 +336,7 @@ export default function fixGoogleHtml () {
     unInlineStyles(tree);
     moveSpaceOutsideSensitiveChildren(tree);
     fixNestedLists(tree);
+    detectTableColumnAlignment(tree);
     unwrapLineBreaks(tree);
     removeLineBreaksBeforeBlocks(tree);
     return tree;


### PR DESCRIPTION
Detect the alignment of a table column based on its cells (Google Docs sets alignment on elements in the cells, not on the cells or columns themselves) and ensure the resulting table has the correct alignment for the column. Output is now like:

```markdown
| Column 1 | Column 2 |
| -------- | -------: |
| Left     |    Right |
| Aligned  |  Aligned |
```

Originally done as part of #52.