### PR TITLE
Automatically update Google Docs fixtures

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Download Fixtures
         run: npm run download-fixtures
-      
+
       # Check whether the "*.copy.html" fixtures changed.
       # The create-pull-request action automatically detects changes, but we
       # have an issue where the "*.export.html" fixtures erroneously change
@@ -33,14 +33,12 @@ jobs:
       - id: detect_updates
         run: |
           echo 'Git changes:'
-          git status -s | grep '^ M test/fixtures/.*\.copy\.html'
-
-          if [ "$?" -eq 0 ]; then
+          if git status -s | grep '^ M test/fixtures/.*\.copy\.html'; then
             echo 'Copy fixtures were changed'
-            echo 'copy_fixtures_changed=true' >> $GITHUB_OUTPUT
+            echo 'copy_fixtures_changed=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'Copy fixtures not changed'
-            echo 'copy_fixtures_changed=' >> $GITHUB_OUTPUT
+            echo 'copy_fixtures_changed=' >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Create PR

--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -1,0 +1,53 @@
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 17 * * 2' # Noon Pacific on Tuesdays
+
+name: Update Fixtures From Google Docs
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download Fixtures
+        run: npm run download-fixtures
+      
+      # Check whether the "*.copy.html" fixtures changed.
+      # The create-pull-request action automatically detects changes, but we
+      # have an issue where the "*.export.html" fixtures erroneously change
+      # even when the change is not meaningful. The "*.copy.html" ones are
+      # stable, though, so we use them as an indicator about whether there were
+      # changes worth committing.
+      - id: detect_updates
+        run: |
+          echo 'Git changes:'
+          git status -s | grep '^ M test/fixtures/.*\.copy\.html'
+
+          if [ "$?" -eq 0 ]; then
+            echo 'Copy fixtures were changed'
+            echo 'copy_fixtures_changed=true' >> $GITHUB_OUTPUT
+          else
+            echo 'Copy fixtures not changed'
+            echo 'copy_fixtures_changed=' >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR
+        if: ${{ steps.detect_updates.outputs.copy_fixtures_changed == 'true' }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: 'auto/fixture-update'
+          delete-branch: true
+          commit-message: 'Automated fixture update from Google Docs'
+          title: 'Update Fixtures'


### PR DESCRIPTION
Since most of our fixtures are actual Google Docs docs, we need to periodically update our local copies in case the copy/export formats for Google Docs change. This adds a scheduled workflow to download fixtures, and if they've changed, create a PR.