### PR TITLE
Run update workflow with correct Node.js version

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Whoops, the update-fixtures workflow needs Node.js v18+.