### PR TITLE
Add GitHub alt text bot

### DIFF
--- a/.github/workflows/discussion-accessibility.yml
+++ b/.github/workflows/discussion-accessibility.yml
@@ -23,4 +23,4 @@ jobs:
     if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
     steps:
       - name: Check alt text with 'github/accessibility-alt-text-bot'
-        uses: github/accessibility-alt-text-bot@v1.2
+        uses: github/accessibility-alt-text-bot@v1.2.0

--- a/.github/workflows/discussion-accessibility.yml
+++ b/.github/workflows/discussion-accessibility.yml
@@ -1,0 +1,26 @@
+name: Discussion Accessibility
+on: 
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+  
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text in issues/PRs/discussions
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
+    steps:
+      - name: Check alt text with 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.2


### PR DESCRIPTION
This sets up GitHub's official action to check image alt text in issues, PRs, and discussions. See more about it in this blog post: https://github.blog/2023-06-12-make-your-github-projects-more-accessible-with-accessibility-alt-text-bot/

I haven't tried this on any other repos yet, but it looks like a useful tool.
