### PR TITLE
Install correct Chromedriver version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 detect_chromedriver_version=true
-include_chromium=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+detect_chromedriver_version=true
+include_chromium=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@wdio/local-runner": "^8.8.8",
         "@wdio/mocha-framework": "^8.8.6",
         "@wdio/spec-reporter": "^8.8.6",
-        "chromedriver": "^112.0.0",
+        "chromedriver": "^114.0.2",
         "copy-webpack-plugin": "^10.2.4",
         "geckodriver": "^3.2.0",
         "hastscript": "^7.0.2",
@@ -3542,9 +3542,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
-      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -4168,15 +4168,15 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "112.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
-      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
+      "version": "114.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.2.tgz",
+      "integrity": "sha512-v0qrXRBknbxqmtklG7RWOe3TJ/dLaHhtB0jVxE7BAdYERxUjEaNRyqBwoGgVfQDibHCB0swzvzsj158nnfPgZw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^5.0.3",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
@@ -4186,7 +4186,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/chromium-bidi": {
@@ -15601,9 +15601,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
-      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.15.0",
@@ -16066,14 +16066,14 @@
       }
     },
     "chromedriver": {
-      "version": "112.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
-      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
+      "version": "114.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.2.tgz",
+      "integrity": "sha512-v0qrXRBknbxqmtklG7RWOe3TJ/dLaHhtB0jVxE7BAdYERxUjEaNRyqBwoGgVfQDibHCB0swzvzsj158nnfPgZw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.2.1",
-        "compare-versions": "^5.0.1",
+        "axios": "^1.4.0",
+        "compare-versions": "^5.0.3",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@wdio/local-runner": "^8.8.8",
     "@wdio/mocha-framework": "^8.8.6",
     "@wdio/spec-reporter": "^8.8.6",
-    "chromedriver": "^112.0.0",
+    "chromedriver": "^114.0.2",
     "copy-webpack-plugin": "^10.2.4",
     "geckodriver": "^3.2.0",
     "hastscript": "^7.0.2",


### PR DESCRIPTION
Tests recently started failing in GitHub actions, and it's because the pre-installed version of Chrome and the version of Chromedriver specified in `package.json` fell out of sync. This installs the latest Chromedriver, but also adds some NPM configuration options to make this future-proof by installing the correct, matching versions of Chromedriver and Chromium itself, rather than the specific on in `package.json`.

As a side note, it *seems* like we should only need to specify `include_chromium=true` (so we have a version of Chromium that matches Chromedriver), but that setting is ignored unless `detect_chromedriver_version=true` is also set, which seems counterintuitive to me (if you are installing a compatible chromium, you shouldn’t need to detect the version, since you are installing a known-compatible version, but maybe I’ve got the mental model wrong here).