### PR TITLE
Turn on Dependabot for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    allow:
+      - dependency-type: "development"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-type: "production"
+    versioning-strategy: widen


### PR DESCRIPTION
I think I hadn't configured this previously because of interest in publishing this as a library on NPM (#42), but to be honest I don't recall exactly. In any case, I realized today I could create separate update configuration for dev and production dependencies, which solves any issues I think I would have been concerned about. (There are no production dependencies right now, but I'll have to shift hast/unified/etc. to production to publish on NPM, at which point the separate configs will matter.)