### PR TITLE
Clean up trailing spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,8 @@
 indent_size = 2
 indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.md]
 indent_size = 4
+trim_trailing_whitespace = false

--- a/.github/workflows/discussion-accessibility.yml
+++ b/.github/workflows/discussion-accessibility.yml
@@ -1,5 +1,5 @@
 name: Discussion Accessibility
-on: 
+on:
   issues:
     types: [opened, edited]
   pull_request:
@@ -15,7 +15,7 @@ permissions:
   issues: write
   pull-requests: write
   discussions: write
-  
+
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text in issues/PRs/discussions

--- a/index.html
+++ b/index.html
@@ -9,19 +9,19 @@
       * {
         box-sizing: border-box;
       }
-      
+
       html, body {
         background: #eee;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
         height: 100%;
         margin: 0;
       }
-      
+
       body {
         display: flex;
         flex-direction: column;
       }
-      
+
       main {
         display: flex;
         flex: 1 1 auto;
@@ -30,30 +30,30 @@
         width: 100%;
         padding: 1em 2em;
       }
-      
+
       #app-header {
         flex: 0 0 auto;
         margin: 0;
         padding: 1em 2em;
       }
-      
+
       #app-header h1 {
         margin: 0;
         padding: 0;
       }
-      
+
       .input-field {
         border: 1px solid #ccc;
         font-size: 1em;
         overflow: auto;
         padding: 1em;
       }
-      
+
       #input-area {
         position: relative;
         width: calc(50% - 1em);
       }
-      
+
       .instructions {
         font-size: 2em;
         font-weight: bold;
@@ -65,7 +65,7 @@
         right: 0;
         text-align: center;
       }
-      
+
       #input {
         position: absolute;
         left: 0;
@@ -74,12 +74,12 @@
         bottom: 0;
         z-index: 1;
       }
-      
+
       #output-area {
         position: relative;
         width: calc(50% - 1em);
       }
-      
+
       #output {
         background: transparent;
         position: absolute;
@@ -110,13 +110,13 @@
     <header id="app-header">
       <h1>Convert Google Docs to Markdown</h1>
     </header>
-    
+
     <main>
       <div id="input-area">
         <p class="instructions">Paste Google Docs text here…</p>
         <div id="input" class="input-field" contenteditable autocomplete="off"></div>
       </div>
-      
+
       <div id="output-area">
         <button id="copy-button" style="display: none;">Copy Markdown</button>
         <p class="instructions">…and get your Markdown here</p>

--- a/lib/log-tree.js
+++ b/lib/log-tree.js
@@ -10,13 +10,13 @@ export default function logTree () {
     else if (node.type === 'element') {
       name = `<${node.tagName}>`;
     }
-    
+
     console.log(`${' '.repeat(indent)}- ${name}`);
-    
+
     if (node.children) {
       node.children.forEach(child => logNode(child, indent + 2));
     }
   }
-  
+
   return tree => logNode(tree);
 }

--- a/lib/rehype-to-remark-with-spaces.js
+++ b/lib/rehype-to-remark-with-spaces.js
@@ -3,13 +3,13 @@ import rehypeRemark from 'rehype-remark';
 /**
  * The official rehype-remark plugin gets a little aggeressive with removing
  * spaces, so this wraps it with some space preservation.
- * 
+ *
  * Ideally, this needs to be solved upstream in rehype-remark.
  * TODO: create a minimal test case and file a bug there!
  */
 export default function rehype2remarkWithSpaces () {
   const spaceToken = '++IAMASPACE++';
-  
+
   function preserveInitialSpaces (node) {
     if (node.type === 'text' && node.value.startsWith(' ')) {
       if (node.value.startsWith(' ')) {
@@ -23,7 +23,7 @@ export default function rehype2remarkWithSpaces () {
       node.children.forEach(preserveInitialSpaces);
     }
   }
-  
+
   function recreateSpaces (node) {
     if (node.value && typeof node.value === 'string') {
       node.value = node.value.split(spaceToken).join(' ');
@@ -32,7 +32,7 @@ export default function rehype2remarkWithSpaces () {
       node.children.forEach(recreateSpaces);
     }
   }
-  
+
   const convert = rehypeRemark.apply(this, arguments);
   return function (tree, file) {
     preserveInitialSpaces(tree);


### PR DESCRIPTION
This is just a minor formatting cleanup to remove trailing spaces from code files (this doesn't affect Markdown files, where trailing spaces are significant).