### PR TITLE
Add download button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+.DS_Store
+
 node_modules
 dist
 logs
+temp
 coverage
 
 scratch.*

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ This project is open source, and gets better with the hard work and collaboratio
 | Contributions | Name |
 | ----: | :---- |
 | [💻](# "Code")  | [Michael Bianco](https://github.com/iloveitaly) |
-| [🚧](# "Maintenance") [💻](# "Code") [🚇](# "Infrastructure") [📖](# "Documentation") [👀](# "Reviewer") | [Rob Brackett](https://github.com/Mr0grog) |
-| [💻](# "Code")  | [Peter Law](https://github.com/PeterJCLaw) |
+| [🚧](# "Maintenance") [💻](# "Code") [🚇](# "Infrastructure") [⚠️](# "Tests") [📖](# "Documentation") [👀](# "Reviewer") | [Rob Brackett](https://github.com/Mr0grog) |
+| [💻](# "Code") [⚠️](# "Tests") | [Jack Kingsman](https://github.com/jkingsman) |
+| [💻](# "Code") | [Peter Law](https://github.com/PeterJCLaw) |
 | [📖](# "Documentation") [🚇](# "Infrastructure") | [Marcin Rataj](https://github.com/lidel) |
-| [💻](# "Code")  | [Ben Sheldon](https://github.com/bensheldon) |
+| [💻](# "Code") | [Ben Sheldon](https://github.com/bensheldon) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 (For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://allcontributors.org/docs/en/emoji-key))

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
         font-style: italic;
       }
 
-      #copy-button {
+      #button-container {
         position: absolute;
         right: 0;
         top: 0;
@@ -118,7 +118,10 @@
       </div>
 
       <div id="output-area">
-        <button id="copy-button" style="display: none;">Copy Markdown</button>
+        <div id="button-container">
+          <button id="download-button" style="display: none;">Download Markdown</button>
+          <button id="copy-button" style="display: none;">Copy Markdown</button>
+        </div>
         <p class="instructions">…and get your Markdown here</p>
         <textarea id="output" class="input-field" autocomplete="off"></textarea>
       </div>

--- a/index.js
+++ b/index.js
@@ -31,3 +31,28 @@ if (navigator.clipboard && navigator.clipboard.writeText) {
     });
   });
 }
+
+const downloadButton = document.getElementById('download-button');
+if (window.URL && window.File) {
+  downloadButton.style.display = '';
+  downloadButton.addEventListener('click', () => {
+    // generate file  
+    const file = new window.File(
+      [outputElement.value],
+      'Converted Text.md', {
+      type: "text/markdown",
+    });
+
+    // make a link and click it
+    const link = document.createElement("a");
+    const url = window.URL.createObjectURL(file);
+    link.href = url;
+    link.download = file.name;
+    document.body.appendChild(link);
+    link.click();
+
+    // cleanup
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  });
+}

--- a/index.js
+++ b/index.js
@@ -36,21 +36,25 @@ const downloadButton = document.getElementById('download-button');
 if (window.URL && window.File) {
   downloadButton.style.display = '';
   downloadButton.addEventListener('click', () => {
-    // generate file
-    const file = new window.File([outputElement.value], 'Converted Text.md', {
+    const file = new File([outputElement.value], 'Converted Text.md', {
       type: 'text/markdown',
     });
 
-    // make a link and click it
-    const link = document.createElement('a');
-    const url = window.URL.createObjectURL(file);
-    link.href = url;
-    link.download = file.name;
-    document.body.appendChild(link);
-    link.click();
-
-    // cleanup
-    document.body.removeChild(link);
-    window.URL.revokeObjectURL(url);
+    // Make a link to the file and click it to trigger a download. Chrome has a
+    // fancy API for opening a save dialog, but other browsers do not, and this
+    // is the most universal way to download a file created in the front-end.
+    let url, link;
+    try {
+      url = URL.createObjectURL(file);
+      link = document.createElement('a');
+      link.href = url;
+      link.download = file.name;
+      document.body.appendChild(link);
+      link.click();
+    }
+    finally {
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }
   });
 }

--- a/index.js
+++ b/index.js
@@ -37,14 +37,12 @@ if (window.URL && window.File) {
   downloadButton.style.display = '';
   downloadButton.addEventListener('click', () => {
     // generate file
-    const file = new window.File(
-      [outputElement.value],
-      'Converted Text.md', {
-      type: "text/markdown",
+    const file = new window.File([outputElement.value], 'Converted Text.md', {
+      type: 'text/markdown',
     });
 
     // make a link and click it
-    const link = document.createElement("a");
+    const link = document.createElement('a');
     const url = window.URL.createObjectURL(file);
     link.href = url;
     link.download = file.name;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const downloadButton = document.getElementById('download-button');
 if (window.URL && window.File) {
   downloadButton.style.display = '';
   downloadButton.addEventListener('click', () => {
-    // generate file  
+    // generate file
     const file = new window.File(
       [outputElement.value],
       'Converted Text.md', {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
       "url": "https://github.com/iloveitaly"
     },
     {
+      "name": "Jack Kingsman",
+      "url": "https://github.com/jkingsman"
+    },
+    {
       "name": "Peter Law",
       "url": "https://github.com/PeterJCLaw"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "type": "module",
   "scripts": {
     "build": "mkdir -p dist && webpack",
-    "clean": "rm -rf dist/*; rm -rf logs/*",
+    "clean": "rm -rf dist/*; rm -rf logs/*; rm -rf temp/*",
     "start": "mkdir -p dist && webpack serve",
     "test": "npm run test-unit && npm run test-e2e",
     "test-unit": "wdio run ./wdio.conf.unit.js --coverage",

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -46,7 +46,14 @@ describe('Basic functionality', () => {
     await expect($outputInstructions).not.toBeDisplayed();
   });
 
-  it('should download the markdown when the button is clicked', async () => {
+  it('downloads the markdown when the button is clicked', async function() {
+    if (browser.capabilities.browserName === 'Safari') {
+      this.skip(
+        "Test not supported in Safari - we can't choose the download directory."
+      );
+      return;
+    }
+
     await browser.url('/');
 
     const $input = await $('#input');

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 
 import { browser, $, expect } from '@wdio/globals';
 
@@ -72,10 +72,9 @@ describe('Basic functionality', () => {
 
     const downloadDirectory = getTestTempDirectory(browser);
     const filePath = path.join(downloadDirectory, "Converted Text.md");
-    await waitForFileExists(filePath, 5_000);
+    await waitForFileExists(filePath);
 
-    // FIXME: use fs/promises API instead of sync API
-    const fileContents = fs.readFileSync(filePath, 'utf-8');
+    const fileContents = await fs.readFile(filePath, 'utf-8');
     await expect(fileContents).toBe('**convert me**\n')
   });
 

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -74,8 +74,10 @@ describe('Basic functionality', () => {
     const filePath = path.join(downloadDirectory, "Converted Text.md");
     await waitForFileExists(filePath, 10_000);
 
+    // FIXME: use fs/promises API instead of sync API
     const fileContents = fs.readFileSync(filePath, 'utf-8');
     await expect(fileContents).toBe('**convert me**\n')
   });
+
   // TODO: test copy button (requires serving over HTTPS in some browsers)
 });

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -70,11 +70,9 @@ describe('Basic functionality', () => {
     const $download_button = await $('#download-button');
     await $download_button.click();
 
-    const filePath = path.join(global.downloadDir, "Converted Text.md");
-    await browser.call(function (){
-      // call our custom function that checks for the file to exist
-      return waitForFileExists(filePath, 60000)
-    });
+    const downloadDirectory = global.downloadsPaths[browser.capabilities.browserName.toLowerCase()];
+    const filePath = path.join(downloadDirectory, "Converted Text.md");
+    await waitForFileExists(filePath, 10_000);
 
     const fileContents = fs.readFileSync(filePath, 'utf-8');
     await expect(fileContents).toBe('**convert me**\n')

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -1,8 +1,6 @@
-import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-
+import * as path from 'node:path';
 import { browser, $, expect } from '@wdio/globals';
-
 import { getTestTempDirectory, waitForFileExists } from '../support/utils.js';
 
 describe('Basic functionality', () => {
@@ -57,7 +55,6 @@ describe('Basic functionality', () => {
     await browser.url('/');
 
     const $input = await $('#input');
-    const $output = await $('#output');
 
     await $input.click();
     // Ideally, this would be `browser.keys([Key.Ctrl, 'b'])`, but only some
@@ -71,11 +68,11 @@ describe('Basic functionality', () => {
     await $download_button.click();
 
     const downloadDirectory = getTestTempDirectory(browser);
-    const filePath = path.join(downloadDirectory, "Converted Text.md");
+    const filePath = path.join(downloadDirectory, 'Converted Text.md');
     await waitForFileExists(filePath);
 
     const fileContents = await fs.readFile(filePath, 'utf-8');
-    await expect(fileContents).toBe('**convert me**\n')
+    await expect(fileContents).toBe('**convert me**\n');
   });
 
   // TODO: test copy button (requires serving over HTTPS in some browsers)

--- a/test/e2e/basic.test.js
+++ b/test/e2e/basic.test.js
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 
 import { browser, $, expect } from '@wdio/globals';
 
-import { waitForFileExists } from '../support/utils.js';
+import { getTestTempDirectory, waitForFileExists } from '../support/utils.js';
 
 describe('Basic functionality', () => {
   it('should convert input and display in output area', async () => {
@@ -70,9 +70,9 @@ describe('Basic functionality', () => {
     const $download_button = await $('#download-button');
     await $download_button.click();
 
-    const downloadDirectory = global.downloadsPaths[browser.capabilities.browserName.toLowerCase()];
+    const downloadDirectory = getTestTempDirectory(browser);
     const filePath = path.join(downloadDirectory, "Converted Text.md");
-    await waitForFileExists(filePath, 10_000);
+    await waitForFileExists(filePath, 5_000);
 
     // FIXME: use fs/promises API instead of sync API
     const fileContents = fs.readFileSync(filePath, 'utf-8');

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -2,6 +2,24 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 
 /**
+ * Get the absolute path a temporary directory that tests can use for working
+ * with files and that test browsers are configured to download files to.
+ * @param {string|{browserName: string}|{capabilities: {browserName: string}}} browser
+ *        The name of the browser/test environment to get a temp directory for,
+ *        or a Webdriver capabilities or browser object identifying the browser.
+ * @returns {string}
+ */
+export function getTestTempDirectory(browser) {
+  const browserName = browser?.capabilities?.browserName
+    ?? browser?.browserName
+    ?? browser;
+  if (typeof browserName !== 'string') {
+    throw new TypeError('The first argument must be a string or browser/capability object');
+  }
+  return path.join(global.tempDirectory, browserName.toLowerCase());
+}
+
+/**
  * Wait until a file exists or a timeout is hit before resolving
  */
 // pulled from https://stackoverflow.com/a/47764403

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -39,24 +39,27 @@ export async function waitForFileExists(filePath, timeout = 5_000) {
     }));
   }, timeout);
 
-  // Check whether the file already exists and return early if so.
+  // Check whether the file already exists and stop watching if so.
   try {
     await fs.access(filePath, fs.constants.F_OK);
     aborter.abort('File already exists');
     return;
-  } catch (_error) {
+  }
+  catch (_error) {
     try {
       for await (const { eventType, filename } of watcher) {
         if (eventType === 'rename' && filename === basename) {
           return;
         }
       }
-    } catch (error) {
+    }
+    catch (error) {
       // The AbortError you get from watch() is uninformative, so unwrap its
       // cause (if present) and throw that instead.
       throw error.cause || error;
     }
-  } finally {
+  }
+  finally {
     clearTimeout(timer);
   }
 }

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -5,6 +5,7 @@ import * as fs from 'node:fs';
  * Wait until a file exists or a timeout is hit before resolving
  */
 // pulled from https://stackoverflow.com/a/47764403
+// FIXME: use fs/promises API, see about making this a proper async function
 export function waitForFileExists(filePath, timeout) {
   return new Promise(function (resolve, reject) {
 

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -1,0 +1,34 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+/**
+ * Wait until a file exists or a timeout is hit before resolving
+ */
+// pulled from https://stackoverflow.com/a/47764403
+export function waitForFileExists(filePath, timeout) {
+  return new Promise(function (resolve, reject) {
+
+    var timer = setTimeout(function () {
+      watcher.close();
+      reject(new Error('File did not exists and was not created during the timeout.'));
+    }, timeout);
+
+    fs.access(filePath, fs.constants.R_OK, function (err) {
+      if (!err) {
+        clearTimeout(timer);
+        watcher.close();
+        resolve();
+      }
+    });
+
+    var dir = path.dirname(filePath);
+    var basename = path.basename(filePath);
+    var watcher = fs.watch(dir, function (eventType, filename) {
+      if (eventType === 'rename' && filename === basename) {
+        clearTimeout(timer);
+        watcher.close();
+        resolve();
+      }
+    });
+  });
+}

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -5,7 +5,13 @@ const IS_CI = /^(true|1)$/i.test(process.env.ci?.trim() || '');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const downloadDir = global.downloadDir = path.join(__dirname, 'temp');
+const tempDirectory = global.tempDirectory = path.join(__dirname, 'temp');
+global.downloadsPaths = {
+  chrome: path.join(tempDirectory, 'chrome'),
+  firefox: path.join(tempDirectory, 'firefox'),
+  // No way to set the downloads directory in Safaridriver. :(
+  safari: null,
+};
 
 let capabilities = [
   {
@@ -15,7 +21,7 @@ let capabilities = [
       prefs: {
         'directory_upgrade': true,
         'prompt_for_download': false,
-        'download.default_directory': downloadDir
+        'download.default_directory': downloadsPaths.chrome
       },
     }
   },
@@ -33,10 +39,10 @@ let capabilities = [
         'browser.download.folderList': 2,
         // Only `browser.download.dir` is really required, but set all the
         // relevant download directory variables just in case.
-        'browser.download.dir': downloadDir,
-        'browser.download.downloadDir': downloadDir,
-        'browser.download.defaultFolder': downloadDir,
-        'browser.download.lastDir': downloadDir,
+        'browser.download.dir': downloadsPaths.firefox,
+        'browser.download.downloadDir': downloadsPaths.firefox,
+        'browser.download.defaultFolder': downloadsPaths.firefox,
+        'browser.download.lastDir': downloadsPaths.firefox,
       }
     }
   },

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -1,17 +1,12 @@
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { getTestTempDirectory } from './test/support/utils.js';
 
 const IS_CI = /^(true|1)$/i.test(process.env.ci?.trim() || '');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const tempDirectory = global.tempDirectory = path.join(__dirname, 'temp');
-global.downloadsPaths = {
-  chrome: path.join(tempDirectory, 'chrome'),
-  firefox: path.join(tempDirectory, 'firefox'),
-  // No way to set the downloads directory in Safaridriver. :(
-  safari: null,
-};
+global.tempDirectory = path.join(__dirname, 'temp');
 
 let capabilities = [
   {
@@ -21,7 +16,7 @@ let capabilities = [
       prefs: {
         'directory_upgrade': true,
         'prompt_for_download': false,
-        'download.default_directory': downloadsPaths.chrome
+        'download.default_directory': getTestTempDirectory('chrome')
       },
     }
   },
@@ -39,10 +34,10 @@ let capabilities = [
         'browser.download.folderList': 2,
         // Only `browser.download.dir` is really required, but set all the
         // relevant download directory variables just in case.
-        'browser.download.dir': downloadsPaths.firefox,
-        'browser.download.downloadDir': downloadsPaths.firefox,
-        'browser.download.defaultFolder': downloadsPaths.firefox,
-        'browser.download.lastDir': downloadsPaths.firefox,
+        'browser.download.dir': getTestTempDirectory('firefox'),
+        'browser.download.downloadDir': getTestTempDirectory('firefox'),
+        'browser.download.defaultFolder': getTestTempDirectory('firefox'),
+        'browser.download.lastDir': getTestTempDirectory('firefox'),
       }
     }
   },
@@ -50,6 +45,7 @@ let capabilities = [
     browserName: 'safari',
     acceptInsecureCerts: true,
     // There's no clear way to set the download dir in safaridriver. :(
+    // Any download-related tests should probably be skipped on Safari.
   }
 ];
 

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -1,9 +1,23 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const IS_CI = /^(true|1)$/i.test(process.env.ci?.trim() || '');
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const downloadDir = global.downloadDir = path.join(__dirname, 'temp');
 
 let capabilities = [
   {
     browserName: 'chrome',
     acceptInsecureCerts: true,
+    'goog:chromeOptions': {
+      prefs: {
+        'directory_upgrade': true,
+        'prompt_for_download': false,
+        'download.default_directory': global.downloadDir
+      },
+    }
   },
   {
     browserName: 'firefox',

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -12,8 +12,8 @@ global.tempDirectory = path.join(__dirname, 'temp');
 // Configuration for all testable browsers.
 let capabilities = [
   {
-    browserName: 'chrome',
-    acceptInsecureCerts: true,
+    'browserName': 'chrome',
+    'acceptInsecureCerts': true,
     'goog:chromeOptions': {
       prefs: {
         'directory_upgrade': true,
@@ -23,8 +23,8 @@ let capabilities = [
     }
   },
   {
-    browserName: 'firefox',
-    acceptInsecureCerts: true,
+    'browserName': 'firefox',
+    'acceptInsecureCerts': true,
     'moz:firefoxOptions': {
       // For detailed descriptions of Firefox prefs, see:
       // - http://kb.mozillazine.org/About:config_entries

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getTestTempDirectory } from './test/support/utils.js';
@@ -8,6 +9,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 global.tempDirectory = path.join(__dirname, 'temp');
 
+// Configuration for all testable browsers.
 let capabilities = [
   {
     browserName: 'chrome',
@@ -105,4 +107,18 @@ export const config = {
     ui: 'bdd',
     timeout: 60_000
   },
+
+  async onPrepare (_config, capabilities) {
+    // Ensure we have a clean temp directory.
+    await fs.rm(global.tempDirectory, { recursive: true, force: true });
+    await fs.mkdir(global.tempDirectory);
+
+    // And a subdirectory for each test environment -- they run in parallel,
+    // so need their own isolated space to play in.
+    for (const capability of capabilities) {
+      const browserDirectory = getTestTempDirectory(capability);
+      await fs.rm(browserDirectory, { recursive: true, force: true });
+      await fs.mkdir(browserDirectory);
+    }
+  }
 };

--- a/wdio.conf.base.js
+++ b/wdio.conf.base.js
@@ -15,17 +15,35 @@ let capabilities = [
       prefs: {
         'directory_upgrade': true,
         'prompt_for_download': false,
-        'download.default_directory': global.downloadDir
+        'download.default_directory': downloadDir
       },
     }
   },
   {
     browserName: 'firefox',
     acceptInsecureCerts: true,
+    'moz:firefoxOptions': {
+      // For detailed descriptions of Firefox prefs, see:
+      // - http://kb.mozillazine.org/About:config_entries
+      // - https://searchfox.org/mozilla-central/source/modules/libpref/init/all.js
+      prefs: {
+        // Don't show a dialog.
+        'browser.download.useDownloadDir': true,
+        // Use the dir set below.
+        'browser.download.folderList': 2,
+        // Only `browser.download.dir` is really required, but set all the
+        // relevant download directory variables just in case.
+        'browser.download.dir': downloadDir,
+        'browser.download.downloadDir': downloadDir,
+        'browser.download.defaultFolder': downloadDir,
+        'browser.download.lastDir': downloadDir,
+      }
+    }
   },
   {
     browserName: 'safari',
     acceptInsecureCerts: true,
+    // There's no clear way to set the download dir in safaridriver. :(
   }
 ];
 

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -1,5 +1,14 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'url';
+
 import { config as base } from './wdio.conf.base.js';
 import WebpackDevServerService from './test/support/wdio-webpack-dev-server.js';
+
+// shim __dirname since we're in an ES module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+global.downloadDir = path.join(__dirname, 'tempDownload');
 
 export const config = {
   ...base,
@@ -11,5 +20,40 @@ export const config = {
   services: [
     ...base.services,
     [WebpackDevServerService, {}]
-  ]
+  ],
+  // chrome configuration for download testing
+  capabilities: [{
+    browserName: 'chrome',
+    'goog:chromeOptions': {
+      prefs: {
+        'directory_upgrade': true,
+        'prompt_for_download': false,
+        'download.default_directory': downloadDir
+      },
+      args: [
+        'headless',
+        'disable-gpu'
+      ]
+    }
+  },
+  {
+    browserName: 'firefox'
+  },
+  {
+    browserName: 'safari'
+  }],
+  onPrepare: function (config, capabilities) {
+    // make sure download directory exists
+    if (!fs.existsSync(downloadDir)){
+        // if it doesn't exist, create it
+        fs.mkdirSync(downloadDir);
+    }
+  },
+  onComplete: function() {
+    console.log(downloadDir)
+    fs.rmSync(downloadDir, {
+      recursive: true,
+      force: true
+    });
+  }
 };

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -14,18 +14,21 @@ export const config = {
     ...base.services,
     [WebpackDevServerService, {}]
   ],
-  onPrepare: function (config, capabilities) {
-    // make sure download directory exists
-    if (!fs.existsSync(global.downloadDir)){
-        // if it doesn't exist, create it
-        fs.mkdirSync(global.downloadDir);
+  onPrepare: function (_config, capabilities) {
+    if (fs.existsSync(global.tempDirectory)) {
+      fs.rmSync(global.tempDirectory, {
+        recursive: true,
+        force: true
+      });
     }
-  },
-  onComplete: function() {
-    console.log(global.downloadDir)
-    fs.rmSync(global.downloadDir, {
-      recursive: true,
-      force: true
-    });
+    fs.mkdirSync(global.tempDirectory);
+
+    // Ensure each browser has a temporary downloads directory to work with.
+    for (const capability of capabilities) {
+      const downloadsPath = global.downloadsPaths[capability.browserName.toLowerCase()];
+      if (downloadsPath && !fs.existsSync(downloadsPath)){
+          fs.mkdirSync(downloadsPath);
+      }
+    }
   }
 };

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -14,6 +14,7 @@ export const config = {
     ...base.services,
     [WebpackDevServerService, {}]
   ],
+  // FIXME: move to base configuration, use an async function and fs/promises API
   onPrepare: function (_config, capabilities) {
     if (fs.existsSync(global.tempDirectory)) {
       fs.rmSync(global.tempDirectory, {

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -1,14 +1,7 @@
-import * as path from 'node:path';
 import * as fs from 'node:fs';
-import { fileURLToPath } from 'url';
 
 import { config as base } from './wdio.conf.base.js';
 import WebpackDevServerService from './test/support/wdio-webpack-dev-server.js';
-
-// shim __dirname since we're in an ES module
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-global.downloadDir = path.join(__dirname, 'tempDownload');
 
 export const config = {
   ...base,
@@ -21,37 +14,16 @@ export const config = {
     ...base.services,
     [WebpackDevServerService, {}]
   ],
-  // chrome configuration for download testing
-  capabilities: [{
-    browserName: 'chrome',
-    'goog:chromeOptions': {
-      prefs: {
-        'directory_upgrade': true,
-        'prompt_for_download': false,
-        'download.default_directory': downloadDir
-      },
-      args: [
-        'headless',
-        'disable-gpu'
-      ]
-    }
-  },
-  {
-    browserName: 'firefox'
-  },
-  {
-    browserName: 'safari'
-  }],
   onPrepare: function (config, capabilities) {
     // make sure download directory exists
-    if (!fs.existsSync(downloadDir)){
+    if (!fs.existsSync(global.downloadDir)){
         // if it doesn't exist, create it
-        fs.mkdirSync(downloadDir);
+        fs.mkdirSync(global.downloadDir);
     }
   },
   onComplete: function() {
-    console.log(downloadDir)
-    fs.rmSync(downloadDir, {
+    console.log(global.downloadDir)
+    fs.rmSync(global.downloadDir, {
       recursive: true,
       force: true
     });

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -1,7 +1,5 @@
-import * as fs from 'node:fs/promises';
 import { config as base } from './wdio.conf.base.js';
 import WebpackDevServerService from './test/support/wdio-webpack-dev-server.js';
-import { getTestTempDirectory } from './test/support/utils.js';
 
 export const config = {
   ...base,
@@ -13,19 +11,5 @@ export const config = {
   services: [
     ...base.services,
     [WebpackDevServerService, {}]
-  ],
-  // FIXME: move to base configuration, use an async function and fs/promises API
-  async onPrepare (_config, capabilities) {
-    // Ensure we have a clean temp directory.
-    await fs.rm(global.tempDirectory, { recursive: true, force: true });
-    await fs.mkdir(global.tempDirectory);
-
-    // And a subdirectory for each test environment -- they run in parallel,
-    // so need their own isolated space to play in.
-    for (const capability of capabilities) {
-      const browserDirectory = getTestTempDirectory(capability);
-      await fs.rm(browserDirectory, { recursive: true, force: true });
-      await fs.mkdir(browserDirectory);
-    }
-  }
+  ]
 };


### PR DESCRIPTION
Hello! What a delightful tool this is; thank you so much for writing it!

I often want to download my Markdown after I get it, so this adds a download button in browsers that support it using the [File](https://developer.mozilla.org/en-US/docs/Web/API/File) and [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) APIs (i.e. just about every browser for nearly ever).

Download code is based off of [this source](https://javascript.plainenglish.io/javascript-create-file-c36f8bccb3be); not sure how much you care about attribution for something so trivial/atomic, but just want to cite my sources.

I had to do a little reformatting but nothing major (button absolutely positioned => container absolutely positioned that now has two buttons).