### PR TITLE
Use PAT to create automatic PRs

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -45,6 +45,7 @@ jobs:
         if: ${{ steps.detect_updates.outputs.copy_fixtures_changed == 'true' }}
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.PR_CREATION_TOKEN }}
           branch: 'auto/fixture-update'
           delete-branch: true
           commit-message: 'Automated fixture update from Google Docs'


### PR DESCRIPTION
The PRs created by the `update-fixtures` action need a custom token in order to trigger the CI workflows so they get tested (e.g. #86 did not get tests). This adds a tightly scoped PAT that should let the workflow create PRs that then run workflows.

More docs here: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs