### PR TITLE
Add support for checklists

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -512,27 +512,27 @@ export function createCodeBlocks(node) {
 const isChecklistItem = (node) => node.tagName === 'li' && node.properties?.role === 'checkbox';
 
 /**
- * Identify checklists and update the markup do the checklist items start with
- * an actual checkbox input, which will then be correctly converted to Markdown.
+ * Insert actual `<input>` checkboxes at the start of items in checklists.
  *
  * Google Docs checklists use ARIA attributes to indicate that items are
- * checklist items, and in some browsers include a image (!) of a checkbox.
+ * checklist items, and in some browsers include an image (!) of a checkbox.
  * Neither of these cleanly translate to Markdown on their own.
  * @param {RehypeNode} node Fix the tree below this node
  */
 function fixChecklists (node) {
   visit(node, isChecklistItem, (node, _index, _parent) => {
-    // In some browsers, checklist items start with an inline, base64-encoded
-    // image of an (un)checked checkbox. Remove it so we don't get images in
-    // our Markdown output.
+    // As of 2023-08-16, Chrome Canary starts checklist items with an inline,
+    // b64-encoded image of an (un)checked checkbox. Remove it so we don't get
+    // images in our Markdown output.
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i];
-      if (
-        child.type === 'element' &&
-        child.tagName === 'img' &&
-        child.properties?.ariaRoleDescription?.includes('checkbox')
-      ) {
-        node.children.splice(i, 1);
+      if (child.type === 'element') {
+        if (
+          child.tagName === 'img' &&
+          child.properties?.ariaRoleDescription?.includes('checkbox')
+        ) {
+          node.children.splice(i, 1);
+        }
         break;
       }
     }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -509,6 +509,49 @@ export function createCodeBlocks(node) {
   }
 }
 
+const isChecklistItem = (node) => node.tagName === 'li' && node.properties?.role === 'checkbox';
+
+/**
+ * Identify checklists and update the markup do the checklist items start with
+ * an actual checkbox input, which will then be correctly converted to Markdown.
+ *
+ * Google Docs checklists use ARIA attributes to indicate that items are
+ * checklist items, and in some browsers include a image (!) of a checkbox.
+ * Neither of these cleanly translate to Markdown on their own.
+ * @param {RehypeNode} node Fix the tree below this node
+ */
+function fixChecklists (node) {
+  visit(node, isChecklistItem, (node, _index, _parent) => {
+    // In some browsers, checklist items start with an inline, base64-encoded
+    // image of an (un)checked checkbox. Remove it so we don't get images in
+    // our Markdown output.
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (
+        child.type === 'element' &&
+        child.tagName === 'img' &&
+        child.properties?.ariaRoleDescription?.includes('checkbox')
+      ) {
+        node.children.splice(i, 1);
+        break;
+      }
+    }
+
+    const checked = node.properties.ariaChecked?.toLowerCase() === 'true';
+    // The checkbox must be in a <p> element.
+    // See: https://github.com/syntax-tree/hast-util-to-mdast/issues/80
+    node.children.splice(0, 0, {
+      type: 'element',
+      tagName: 'p',
+      children: [{
+        type: 'element',
+        tagName: 'input',
+        properties: { type: 'checkbox', checked }
+      }]
+    });
+  });
+}
+
 /**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
@@ -523,6 +566,7 @@ export default function fixGoogleHtml () {
     detectTableColumnAlignment(tree);
     unwrapLineBreaks(tree);
     removeLineBreaksBeforeBlocks(tree);
+    fixChecklists(tree);
     return tree;
   };
 }

--- a/test/fixtures/lists.expected.md
+++ b/test/fixtures/lists.expected.md
@@ -42,8 +42,7 @@ And a numbered list:
 4. This item has line breaks.\
    Here is a second line.
 
-<!-- FIXME: checklists not yet supported! -->
 And a checklist:
 
-- ~~This is~~
-- A checklist.
+- [x] ~~This is~~
+- [ ] A checklist.

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -52,4 +52,61 @@ describe('convert', () => {
 
     expect(md).toEqual(`This  **_is bold and italic_** &#x20;\n`);
   });
+
+  describe('checklists', () => {
+    // Different browsers get different content on the clipboard for checklists.
+    // We need explicit tests in addition to fixtures from actual docs as above
+    // to make sure we cover  all the cases.
+    //
+    // As of 2023-08-16, most browsers get list items with ARIA markup
+    // indicating they are checkboxes. That's covered by this first test.
+    // Chrome Canary gets the same markup but with inline images of
+    // checked/unchecked checkboxes (second test).
+    it('supports copied checklists without images', async () => {
+      // Removed `style` and `dir` attributes for brevity.
+      let md = await convertDocsHtmlToMarkdown(`
+        <ul>
+          <li role="checkbox" aria-checked="false" aria-level="1">
+            <p role="presentation">
+              <span>Unchecked item</span>
+            </p>
+          </li>
+          <li role="checkbox" aria-checked="true" aria-level="1">
+            <p role="presentation">
+              <span>Checked item</span>
+            </p>
+          </li>
+        </ul>
+    `);
+    expect(md).toEqual(`
+      - [ ] Unchecked item
+      - [x] Checked item
+    `.replace(/^\s+/gm, ''));
+    });
+
+    it('supports copied checklists with images', async () => {
+      // Removed `style` and `dir` attributes for brevity. The images are also
+      // replaced with a simple 1-pixel box for the same reason.
+      let md = await convertDocsHtmlToMarkdown(`
+        <ul>
+        <li role="checkbox" aria-checked="false" aria-level="1">
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" width="17.599999999999998px" height="17.599999999999998px" alt="unchecked" aria-roledescription="checkbox">
+          <p role="presentation">
+            <span>Unchecked item</span>
+          </p>
+        </li>
+          <li role="checkbox" aria-checked="true" aria-level="1">
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" width="17.599999999999998px" height="17.599999999999998px" alt="checked" aria-roledescription="checkbox">
+            <p role="presentation">
+              <span>Checked item</span>
+            </p>
+          </li>
+        </ul>
+      `);
+      expect(md).toEqual(`
+        - [ ] Unchecked item
+        - [x] Checked item
+      `.replace(/^\s+/gm, ''));
+    });
+  });
 });

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -108,5 +108,27 @@ describe('convert', () => {
         - [x] Checked item
       `.replace(/^\s+/gm, ''));
     });
+
+    // This covers a potential edge-case we have not seen.
+    it('keeps images not at the start of a checklist item', async () => {
+      // Removed `style` and `dir` attributes for brevity. The images are also
+      // replaced with a simple 1-pixel box for the same reason.
+      let md = await convertDocsHtmlToMarkdown(`
+        <ul>
+        <li role="checkbox" aria-checked="false" aria-level="1">
+          <span>Unchecked item</span>
+          <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" width="17.599999999999998px" height="17.599999999999998px" alt="unchecked" aria-roledescription="checkbox">
+        </li>
+          <li role="checkbox" aria-checked="true" aria-level="1">
+            <span>Checked item</span>
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" width="17.599999999999998px" height="17.599999999999998px" alt="checked" aria-roledescription="checkbox">
+          </li>
+        </ul>
+      `);
+      expect(md).toEqual(`
+        - [ ] Unchecked item ![unchecked](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==)
+        - [x] Checked item ![checked](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX///+nxBvIAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==)
+      `.replace(/^\s+/gm, ''));
+    });
   });
 });


### PR DESCRIPTION
When you copy checklists from a Google Doc, you get some funky markup that doesn't translate very well to Markdown (and it's different in different browsers, too). This identifies that markup and turns it into lists with real checkboxes, which then convert correctly to GitHub-Flavored Markdown checklists like:

```md
- [x] Checked item
- [ ] Unchecked item
```

Fixes #57.