### PR TITLE
Specify supported versions of Node.js

### DIFF
--- a/.github/workflows/update-fixtures.yml
+++ b/.github/workflows/update-fixtures.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
           cache: npm
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,11 @@ logs
 temp
 coverage
 
+# Ignore tool versioning files -- development and testing should not be hard on
+# multiple versions of Node.js, so we don't want these in the repo, but it's
+# fine (or even good!) for contributors to use them locally.
+.node-version
+.nvmrc
+.tool-versions
+
 scratch.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,9 @@
         "webpack-bundle-analyzer": "^4.9.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rehype-remark": "^9.1.2",
         "remark-gfm": "^3.0.1",
         "remark-stringify": "^10.0.3",
+        "undici": "^5.25.4",
         "unified": "^10.1.2",
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1",
@@ -984,6 +985,15 @@
       "peer": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -12255,6 +12265,18 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "5.25.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
+      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/unified": {
       "version": "10.1.2",
       "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
@@ -14535,6 +14557,12 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "@fastify/busboy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+      "dev": true
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -22579,6 +22607,15 @@
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
+      }
+    },
+    "undici": {
+      "version": "5.25.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.4.tgz",
+      "integrity": "sha512-450yJxT29qKMf3aoudzFpIciqpx6Pji3hEWaXqXmanbXF58LTAGCKxcJjxMXWu3iG+Mudgo3ZUfDB6YDFd/dAw==",
+      "dev": true,
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "unified": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "rehype-remark": "^9.1.2",
     "remark-gfm": "^3.0.1",
     "remark-stringify": "^10.0.3",
+    "undici": "^5.25.4",
     "unified": "^10.1.2",
     "unist-util-visit": "^5.0.0",
     "unist-util-visit-parents": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "webpack-bundle-analyzer": "^4.9.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"
+  },
+  "engines": {
+    "node": ">=16"
   }
 }

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { writeFile } from 'node:fs/promises';
 import { chromium } from 'playwright';
+// We need this for Node.js 16. It's built-in on v18+, so remove if updating.
+import { fetch } from 'undici'
 
 const COMMAND_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 const FIXTURE_PATH = '../test/fixtures';


### PR DESCRIPTION
This supersedes #83. It specifies the minimum required version of Node.js in `package.json` (I should have done that long ago!) and ignores various files for specifying the Node.js version in git, so we don't lock developers into a particular version (since we *intend* to eventually get project into NPM as a library and/or CLI tool and not just a web page, we don't want to lock in a specific version).

It also adds `undici` as a dev dependency so that all the dev scripts actually work on all the versions of Node.js this package is meant to support, which was the original driving issue for #83.