### PR TITLE
Ensure WebdriverIO Dependabot updates are grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: widen
+    groups:
+      # WebdriverIO frequently makes cross-ecosystem changes
+      # that break unless updated together.
+      wdio:
+        patterns:
+          - "@wdio/*"


### PR DESCRIPTION
It turns out WebdriverIO tends to treat interfaces between their packages as private and not subject to semver rules, so you need to be careful about updating them together.