### PR TITLE
Ignore `si` property in slice clip fixtures

### DIFF
--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -313,6 +313,14 @@ function cleanDocumentSliceClip(jsonString) {
   const data = JSON.parse(jsonString);
   data.edi = '<random>';
   data.edrk = '<random>';
+
+  // I'm not totally sure what the `si` property represents, but sometimes it's
+  // included and sometimes it's not, with no noticeable impact. If it's an
+  // empty string, we just remove it in order to reduce pointless changes.
+  if (data.si === '') {
+    delete data.si;
+  }
+
   return JSON.stringify(data, null, 2);
 }
 


### PR DESCRIPTION
We've gotten a few fixture updates that alternately added and removed an `si` property that is an empty string (e.g. #150, #151), so just drop it if it's empty to reduce pointless updates.