### PR TITLE
Added button to copy escaped markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
         <div id="button-container">
           <button id="download-button" style="display: none;">Download Markdown</button>
           <button id="copy-button" style="display: none;">Copy Markdown</button>
+          <button id="copy-escaped-button" style="display: none;">Copy Escaped Markdown</button>
         </div>
         <p class="instructions">…and get your Markdown here</p>
         <textarea id="output" class="input-field" autocomplete="off"></textarea>

--- a/index.js
+++ b/index.js
@@ -59,6 +59,18 @@ if (navigator.clipboard && navigator.clipboard.writeText) {
   });
 }
 
+const copyEscapedButton = document.getElementById('copy-escaped-button');
+if (navigator.clipboard && navigator.clipboard.writeText) {
+  copyEscapedButton.style.display = '';
+  copyEscapedButton.addEventListener('click', () => {
+    navigator.clipboard
+      .writeText(JSON.stringify(outputElement.value))
+      .catch((error) => {
+        alert(`Unable to copy escaped markdown to clipboard: ${error}`);
+      });
+  });
+}
+
 const downloadButton = document.getElementById('download-button');
 if (window.URL && window.File) {
   downloadButton.style.display = '';


### PR DESCRIPTION
Certain usecases require Markdown to be pasted in an escaped format. Eg. sending markdown as data for AI chatbot training via an API. 

To handle such cases, added a handy button to copy JSON escaped markdown.