### PR TITLE
Remove undici dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "rehype-remark": "^10.0.0",
         "remark-gfm": "^4.0.0",
         "remark-stringify": "^11.0.0",
-        "undici": "^5.28.3",
         "unified": "^11.0.4",
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1",
@@ -1012,15 +1011,6 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -12672,18 +12662,6 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dev": true,
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -14783,12 +14761,6 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
-      "dev": true
-    },
-    "@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -23181,15 +23153,6 @@
       "requires": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
-      }
-    },
-    "undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dev": true,
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
       }
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "rehype-remark": "^10.0.0",
     "remark-gfm": "^4.0.0",
     "remark-stringify": "^11.0.0",
-    "undici": "^5.28.3",
     "unified": "^11.0.4",
     "unist-util-visit": "^5.0.0",
     "unist-util-visit-parents": "^6.0.1",

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -5,8 +5,6 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { writeFile } from 'node:fs/promises';
 import { chromium } from 'playwright';
-// We need this for Node.js 16. It's built-in on v18+, so remove if updating.
-import { fetch } from 'undici';
 
 const COMMAND_KEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 const FIXTURE_PATH = '../test/fixtures';


### PR DESCRIPTION
Now that we require Node.js 18+ (#199), undici is built-in and we don't need it as a separate dependency.