### PR TITLE
Support bold text in headings, take 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,26 @@
         top: 0;
         z-index: 2;
       }
+
+      /**
+       * Baseline Styling for Pasted Content
+       *
+       * Different browsers apply a variety of DOM and style normalizations to
+       * content when pasting into a contenteditable node. In some cases,
+       * normalizing against the built-in user agent or page styles will cause
+       * important formatting info to be lost entirely (e.g. bold text in
+       * headings). To prevent those issues, this applies some basic CSS resets
+       * to the input area.
+       */
+      #input h1,
+      #input h2,
+      #input h3,
+      #input h4,
+      #input h5,
+      #input h6 {
+        font-weight: normal;
+        text-decoration: none;
+      }
     </style>
   </head>
   <body>

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -17,6 +17,8 @@ const FIXTURES = {
   'code-blocks-mixed': '1D56ytnyzkCG-OSn6m83B5JxPjwgZ05iSSUUbLuYzmzc',
   'code-inline': '1bEp38sjESFK8q1PLwfesZgNDMwEsqeGulaq4Vb7r9IA',
   'headings-and-paragraphs': '1Dm5DIHOVAvsGYgTaPuhq78PefT_5u10RFsRBxunxBtQ',
+  'headings-with-inline-formatting':
+    '1tZ7s7liAh5l-w7Eu7Meej9JfMpUItnyJ3q2yC6juB3c',
   'inline-formatting': '1-0E8y62m1tI6MWYYbGcbBALylL9hT9Toq9SssCeT-Ew',
   'lists': '1bZI3NwaasFZGexGQG9YC07UAovpY9b_mfdI2_KgT8-0',
   'list-item-level-styling': '10W_0kk4mBViHMIahKcg4WwBu-HLCyw12BG7NC2lyuA8',

--- a/test/fixtures/headings-with-inline-formatting.copy.gdocsliceclip.json
+++ b/test/fixtures/headings-with-inline-formatting.copy.gdocsliceclip.json
@@ -1,0 +1,1737 @@
+{
+  "cses": false,
+  "data": {
+    "autotext_content": {
+    },
+    "resolved": {
+      "dsl_drawingrevisionaccesstokenmap": {
+      },
+      "dsl_entitymap": {
+      },
+      "dsl_entitypositionmap": {
+      },
+      "dsl_entitytypemap": {
+      },
+      "dsl_metastyleslices": [
+        {
+          "stsl_styles": [
+            {
+              "ac_ct": null,
+              "ac_id": "",
+              "ac_ot": null,
+              "ac_sm": {
+                "asm_l": "",
+                "asm_rl": 0,
+                "asm_s": 0
+              },
+              "ac_type": null
+            }
+          ],
+          "stsl_type": "autocorrect"
+        },
+        {
+          "stsl_styles": [
+            {
+              "colc_icc": false
+            }
+          ],
+          "stsl_type": "collapsed_content"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cd_bgc": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "cd_u": false
+            }
+          ],
+          "stsl_type": "composing_decoration"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cr_c": false
+            }
+          ],
+          "stsl_type": "composing_region"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iwos_i": false
+            }
+          ],
+          "stsl_type": "ignore_word"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ocn_sttc": 0,
+              "ocn_tdsm": null,
+              "ocn_tfsm": null
+            }
+          ],
+          "stsl_type": "on_canvas_nudges"
+        },
+        {
+          "stsl_styles": [
+            {
+              "revdiff_a": "",
+              "revdiff_aid": "",
+              "revdiff_dt": 0
+            }
+          ],
+          "stsl_type": "revision_diff"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sc_id": "",
+              "sc_ow": null,
+              "sc_sl": null,
+              "sc_sm": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "sc_sugg": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vcs_c": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "vcs_id": ""
+            }
+          ],
+          "stsl_type": "voice_corrections"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vdss_id": "",
+              "vdss_p": null
+            }
+          ],
+          "stsl_type": "voice_dotted_span"
+        }
+      ],
+      "dsl_nestedmodelmap": {
+      },
+      "dsl_relateddocslices": {
+      },
+      "dsl_spacers": "This is a test of inline formatting in headings.\nHeading with bold and emphasized text\n\nNormal text\n\nAll bold heading\n\nNormal text\n",
+      "dsl_styleslices": [
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "autogen"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "cell"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "code_snippet"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "collapsed_heading"
+        },
+        {
+          "stsl_leading": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_leadingType": "column_sector",
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_trailingType": "column_sector",
+          "stsl_type": "column_sector"
+        },
+        {
+          "stsl_leading": {
+            "ds_b": {
+              "bg_c2": {
+                "clr_type": 0,
+                "hclr_color": null
+              }
+            },
+            "ds_ci": null,
+            "ds_df": {
+              "df_dm": 0
+            },
+            "ds_epfi": null,
+            "ds_ephi": null,
+            "ds_fi": null,
+            "ds_fpfi": null,
+            "ds_fphi": null,
+            "ds_fpo": false,
+            "ds_hi": null,
+            "ds_lhs": 1,
+            "ds_ln": {
+              "ln_lne": false,
+              "ln_lnm": 0
+            },
+            "ds_mb": 72,
+            "ds_mf": 36,
+            "ds_mh": 36,
+            "ds_ml": 72,
+            "ds_mr": 72,
+            "ds_mt": 72,
+            "ds_ph": 792,
+            "ds_pnsi": 1,
+            "ds_pw": 612,
+            "ds_rtd": "",
+            "ds_uephf": false,
+            "ds_ufphf": false,
+            "ds_ulhfl": false
+          },
+          "stsl_leadingType": "document",
+          "stsl_styles": [
+          ],
+          "stsl_type": "document"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation_function"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "esgs_s": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            }
+          },
+          "stsl_trailingType": "esignature_signers",
+          "stsl_type": "esignature_signers"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "field"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "footnote"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "headings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "horizontal_rule"
+        },
+        {
+          "stsl_styles": [
+            {
+              "isc_osh": null,
+              "isc_smer": true
+            }
+          ],
+          "stsl_type": "ignore_spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iws_iwids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "import_warnings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "lgs_l": "en"
+          },
+          "stsl_trailingType": "language",
+          "stsl_type": "language"
+        },
+        {
+          "stsl_styles": [
+            {
+              "lnks_link": null
+            }
+          ],
+          "stsl_type": "link"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            }
+          ],
+          "stsl_type": "list"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ms_id": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "markup"
+        },
+        {
+          "stsl_styles": [
+            {
+              "nrs_ei": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "named_range"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 1,
+              "ps_hdid": "h.p5u4g7pogmv8",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": true,
+              "ps_klt_i": false,
+              "ps_kwn": true,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 6,
+              "ps_sa_i": false,
+              "ps_sb": 20,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 2,
+              "ps_hdid": "h.db62q6ehbz3r",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": true,
+              "ps_klt_i": false,
+              "ps_kwn": true,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 6,
+              "ps_sa_i": false,
+              "ps_sb": 18,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "paragraph"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "row"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sfs_sst": false
+            }
+          ],
+          "stsl_type": "suppress_feature"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "tbl"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": true,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": true,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": true,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 16,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            }
+          ],
+          "stsl_type": "text"
+        }
+      ],
+      "dsl_suggesteddeletions": {
+        "sgsl_sugg": [
+        ]
+      },
+      "dsl_suggestedinsertions": {
+        "sgsl_sugg": [
+        ]
+      }
+    }
+  },
+  "dct": "kix",
+  "dih": 25882830,
+  "ds": false,
+  "edi": "<random>",
+  "edrk": "<random>",
+  "sm": "other"
+}

--- a/test/fixtures/headings-with-inline-formatting.copy.html
+++ b/test/fixtures/headings-with-inline-formatting.copy.html
@@ -1,0 +1,47 @@
+<span id="docs-internal-guid-dddddddd-dddd-dddd-dddd-123456789abc">
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			This is a test of inline formatting in headings.
+		</span>
+	</p>
+	<h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;">
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-weight: 400; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Heading with 
+		</span>
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			bold
+		</span>
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-weight: 400; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			 and 
+		</span>
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-weight: 400; font-style: italic; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			emphasized
+		</span>
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-weight: 400; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			 text
+		</span>
+	</h1>
+	<br>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Normal text
+		</span>
+	</p>
+	<br>
+	<h2 dir="ltr" style="line-height:1.38;margin-top:18pt;margin-bottom:6pt;">
+		<span style="font-size: 16pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			All bold heading
+		</span>
+	</h2>
+	<br>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Normal text
+		</span>
+	</p>
+	<div>
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			<br>
+		</span>
+	</div>
+</span>

--- a/test/fixtures/headings-with-inline-formatting.expected.md
+++ b/test/fixtures/headings-with-inline-formatting.expected.md
@@ -1,0 +1,11 @@
+This is a test of inline formatting in headings.
+
+
+# Heading with **bold** and _emphasized_ text<a id="heading-with-bold-and-emphasized-text"></a>
+
+Normal text
+
+
+## **All bold heading**<a id="all-bold-heading"></a>
+
+Normal text

--- a/test/fixtures/headings-with-inline-formatting.export.html
+++ b/test/fixtures/headings-with-inline-formatting.export.html
@@ -1,0 +1,247 @@
+<html>
+	<head>
+		<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+		<style type="text/css">
+			ol{
+	margin:0;
+	padding:0
+}
+table td,table th{
+	padding:0
+}
+.title{
+	padding-top:0pt;
+	color:#000000;
+	font-size:26pt;
+	padding-bottom:3pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.subtitle{
+	padding-top:0pt;
+	color:#666666;
+	font-size:15pt;
+	padding-bottom:16pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+li{
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+p{
+	margin:0;
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+h1{
+	padding-top:20pt;
+	color:#000000;
+	font-size:20pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h2{
+	padding-top:18pt;
+	color:#000000;
+	font-size:16pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h3{
+	padding-top:16pt;
+	color:#434343;
+	font-size:14pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h4{
+	padding-top:14pt;
+	color:#666666;
+	font-size:12pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h5{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h6{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	font-style:italic;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c1{
+	background-color:#ffffff;
+	max-width:468pt;
+	padding:72pt 72pt 72pt 72pt
+}
+.c10{
+	color:#000000;
+	font-weight:700;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:16pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c2{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c3{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c4{
+	padding-top:20pt;
+	padding-bottom:6pt;
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c5{
+	font-weight:700
+}
+.c6{
+	font-style:italic
+}
+.c7{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:20pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c8{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	orphans:2;
+	widows:2;
+	text-align:left;
+	height:11pt
+}
+.c9{
+	padding-top:18pt;
+	padding-bottom:6pt;
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+
+		</style>
+	</head>
+	<body class="c1 doc-content">
+		<p class="c2">
+			<span class="c3">
+				This is a test of inline formatting in headings.
+			</span>
+		</p>
+		<h1 class="c4" id="h.p5u4g7pogmv8">
+			<span>
+				Heading with 
+			</span>
+			<span class="c5">
+				bold
+			</span>
+			<span>
+				&nbsp;and 
+			</span>
+			<span class="c6">
+				emphasized
+			</span>
+			<span class="c7">
+				&nbsp;text
+			</span>
+		</h1>
+		<p class="c8">
+			<span class="c3">
+			</span>
+		</p>
+		<p class="c2">
+			<span class="c3">
+				Normal text
+			</span>
+		</p>
+		<p class="c8">
+			<span class="c3">
+			</span>
+		</p>
+		<h2 class="c9" id="h.db62q6ehbz3r">
+			<span class="c10">
+				All bold heading
+			</span>
+		</h2>
+		<p class="c8">
+			<span class="c3">
+			</span>
+		</p>
+		<p class="c2">
+			<span class="c3">
+				Normal text
+			</span>
+		</p>
+	</body>
+</html>


### PR DESCRIPTION
When there's bold formatting in headings, we sometimes lose it because browsers normalize the styling and DOM structure when pasting content into a contenteditable node (which is how we currently capture a paste from Google Docs). Specifically, WebKit- and Chromium- based browsers would see that headings are already bold in the user agent stylesheet, and then normalize out all the bold formatting info in the actual DOM and CSS that gets pasted. This solves the issue by "resetting" the styling on headings inside the input area.

This supersedes #158, which took a way more complicated approach to the problem before I realized we could just style input area to prevent normalization in the first place. 🤦  This also has none of the weird edge cases and caveats that complex approach did. 

Fixes #113.