### PR TITLE
Handle suggested changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       }
 
       #app-header h1 {
-        margin: 0;
+        margin: 0 0 0.5em;
         padding: 0;
       }
 
@@ -129,6 +129,18 @@
   <body>
     <header id="app-header">
       <h1>Convert Google Docs to Markdown</h1>
+
+      <form id="settings">
+        <span title="Settings">⚙️</span>
+        <label>
+          Suggested changes:
+          <select name="suggestions">
+            <option value="show">Show suggestions</option>
+            <option value="accept">Accept/use suggestions</option>
+            <option value="reject">Reject/ignore suggestions</option>
+          </select>
+        </label>
+      </form>
     </header>
 
     <main>

--- a/lib-ui/index.js
+++ b/lib-ui/index.js
@@ -1,4 +1,5 @@
-import { convertDocsHtmlToMarkdown, defaultOptions } from './lib/convert.js';
+import { convertDocsHtmlToMarkdown, defaultOptions } from '../lib/convert.js';
+import { settings as currentSettings } from './settings.js';
 import debug from 'debug';
 
 const SLICE_CLIP_MEDIA_TYPE =
@@ -6,6 +7,7 @@ const SLICE_CLIP_MEDIA_TYPE =
 
 const log = debug('app:index:debug');
 
+const settingsForm = document.getElementById('settings');
 const inputElement = document.getElementById('input');
 const outputElement = document.getElementById('output');
 const inputInstructions = document.querySelector('#input-area .instructions');
@@ -55,8 +57,6 @@ inputElement.addEventListener('input', () => {
   convert();
 });
 
-window.convertDocsHtmlToMarkdown = convertDocsHtmlToMarkdown;
-
 const copyButton = document.getElementById('copy-button');
 if (navigator.clipboard && navigator.clipboard.writeText) {
   copyButton.style.display = '';
@@ -93,55 +93,6 @@ if (window.URL && window.File) {
   });
 }
 
-const settingsForm = document.getElementById('settings');
-
-const currentSettings = {
-  get(key) {
-    return this._data[key];
-  },
-
-  getAll() {
-    return Object.assign({}, this._data);
-  },
-
-  set(key, value) {
-    this._data[key] = value;
-    this.save();
-  },
-
-  setAll(newData, { save = true } = {}) {
-    Object.assign(this._data, newData);
-    if (save) {
-      this.save();
-    }
-  },
-
-  toJSON() {
-    return this.getAll();
-  },
-
-  save() {
-    const serialized = JSON.stringify(this);
-    try {
-      window.localStorage.setItem(this._storageKey, serialized);
-    } catch (error) {
-      console.error('Error saving settings:', error);
-    }
-  },
-
-  load() {
-    try {
-      const serialized = window.localStorage.getItem(this._storageKey);
-      this.setAll(JSON.parse(serialized), { save: false });
-    } catch (_error) {
-      // OK: there might be nothing saved.
-    }
-  },
-
-  _storageKey: 'gdoc2md.options',
-  _data: Object.assign(Object.create(null), defaultOptions),
-};
-
 function updateSettingsForm() {
   for (const input of settingsForm.querySelectorAll('input,select')) {
     const value = currentSettings.get(input.name);
@@ -164,5 +115,7 @@ settingsForm.addEventListener('change', (event) => {
   convert();
 });
 
+window.convertDocsHtmlToMarkdown = convertDocsHtmlToMarkdown;
+currentSettings.setAll(defaultOptions, { save: false });
 currentSettings.load();
 updateSettingsForm();

--- a/lib-ui/settings.js
+++ b/lib-ui/settings.js
@@ -1,0 +1,46 @@
+export const settings = {
+  get(key) {
+    return this._data[key];
+  },
+
+  getAll() {
+    return Object.assign({}, this._data);
+  },
+
+  set(key, value) {
+    this._data[key] = value;
+    this.save();
+  },
+
+  setAll(newData, { save = true } = {}) {
+    Object.assign(this._data, newData);
+    if (save) {
+      this.save();
+    }
+  },
+
+  toJSON() {
+    return this.getAll();
+  },
+
+  save() {
+    const serialized = JSON.stringify(this);
+    try {
+      window.localStorage.setItem(this._storageKey, serialized);
+    } catch (error) {
+      console.error('Error saving settings:', error);
+    }
+  },
+
+  load() {
+    try {
+      const serialized = window.localStorage.getItem(this._storageKey);
+      this.setAll(JSON.parse(serialized), { save: false });
+    } catch (_error) {
+      // OK: there might be nothing saved.
+    }
+  },
+
+  _storageKey: 'gdoc2md.options',
+  _data: {},
+};

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -7,10 +7,17 @@ import rehype2remarkWithSpaces from './rehype-to-remark-with-spaces.js';
 import remarkGfm from 'remark-gfm';
 import stringify from 'remark-stringify';
 import { unified } from 'unified';
+// import logTree from './log-tree.js';
 
 /** @typedef {import("mdast-util-to-markdown").State} MdastState */
 /** @typedef {import("unist").Node} UnistNode */
 /** @typedef {import("hast-util-to-mdast").Handle} Handle */
+
+export const defaultOptions = {
+  headingIdValue: 'text',
+  headingIdSyntax: 'html',
+  suggestions: 'show',
+};
 
 /** @type {Handle} */
 function preserveTagAndConvertContents(state, node, _parent) {
@@ -54,12 +61,13 @@ function doubleBlankLinesBeforeHeadings(previous, next, _parent, _state) {
 const processor = unified()
   .use(parse)
   .use(fixGoogleHtml)
-  // .use(require('./lib/log-tree').default)
+  // .use(logTree)
   .use(rehype2remarkWithSpaces, {
     handlers: {
       // Preserve sup/sub markup; most Markdowns have no markup for it.
       sub: preserveTagAndConvertContents,
       sup: preserveTagAndConvertContents,
+      ins: preserveTagAndConvertContents,
       h1: headingWithId,
       h2: headingWithId,
       h3: headingWithId,
@@ -108,13 +116,14 @@ function parseGdocsSliceClip(raw) {
   return data;
 }
 
-export function convertDocsHtmlToMarkdown(html, rawSliceClip) {
+export function convertDocsHtmlToMarkdown(html, rawSliceClip, options) {
   const sliceClip = rawSliceClip ? parseGdocsSliceClip(rawSliceClip) : null;
   return processor
     .process({
       value: html,
       data: {
         sliceClip,
+        options: { ...defaultOptions, ...options },
       },
     })
     .then((result) => result.value);

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -14,9 +14,10 @@ import { unified } from 'unified';
 /** @typedef {import("hast-util-to-mdast").Handle} Handle */
 
 export const defaultOptions = {
+  // TODO: the headings options are not hooked up yet.
   headingIdValue: 'text',
   headingIdSyntax: 'html',
-  suggestions: 'show',
+  suggestions: 'reject',
 };
 
 /** @type {Handle} */

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -644,29 +644,23 @@ function fixInternalLinks(node, sliceClip) {
   });
 
   // Update any links to the headings.
-  visit(
-    node,
-    (n) => n.tagName === 'a', // use isAnchor!!
-    (node, _index, _parent) => {
-      let url;
-      try {
-        url = new URL(node.properties.href);
-      } catch (_error) {
-        return;
-      }
+  visit(node, isAnchor, (node, _index, _parent) => {
+    let url;
+    try {
+      url = new URL(node.properties.href);
+    } catch (_error) {
+      return;
+    }
 
-      if (url.host === 'docs.google.com') {
-        const internalHeadingId = url.hash.match(
-          /^#heading=([a-z0-9.]+)$/
-        )?.[1];
-        log('Updating link to %o', internalHeadingId);
-        const newId = headingIdMap.get(internalHeadingId);
-        if (newId) {
-          node.properties.href = `#${newId}`;
-        }
+    if (url.host === 'docs.google.com') {
+      const internalHeadingId = url.hash.match(/^#heading=([a-z0-9.]+)$/)?.[1];
+      log('Updating link to %o', internalHeadingId);
+      const newId = headingIdMap.get(internalHeadingId);
+      if (newId) {
+        node.properties.href = `#${newId}`;
       }
     }
-  );
+  });
 }
 
 /**

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -63,7 +63,7 @@ const blockElements = new Set([
 
 // These elements convert to Markdown nodes that can't start or end with spaces.
 // For example, you can't start emphasis with a space: `This * is emphasized*`.
-const spaceSensitiveElements = new Set(['em', 'strong']);
+const spaceSensitiveElements = new Set(['em', 'strong', 'ins', 'del']);
 
 const isList = (node) => node.tagName === 'ul' || node.tagName === 'ol';
 const isStyled = (node) => node.type === 'element' && node.properties.style;
@@ -72,6 +72,8 @@ const isSpaceSensitive = (node) =>
   node && spaceSensitiveElements.has(node.tagName);
 const isCell = (node) => node.tagName === 'th' || node.tagName === 'td';
 const isAnchor = (node) => node.tagName === 'a';
+const isText = (node) => node.type === 'text';
+const isSuggestion = (n) => n.properties?.['data-suggestion-id'] != null;
 
 const spaceAtStartPattern = /^(\s+)/;
 const spaceAtEndPattern = /(\s+)$/;
@@ -644,7 +646,7 @@ function fixInternalLinks(node, sliceClip) {
   // Update any links to the headings.
   visit(
     node,
-    (n) => n.tagName === 'a',
+    (n) => n.tagName === 'a', // use isAnchor!!
     (node, _index, _parent) => {
       let url;
       try {
@@ -668,12 +670,201 @@ function fixInternalLinks(node, sliceClip) {
 }
 
 /**
+ * Visit each range of text as found in a HAST tree. You can replace or change
+ * the node from within the visitor and it should continue to work.
+ * @param {string} docsText
+ * @param {GDocsRange[]} ranges
+ * @param {RehypeNode} tree
+ * @param {function} visitor
+ */
+function forEachDocsRangeInTree(docsText, ranges, tree, visitor) {
+  if (ranges.length === 0) return;
+
+  ranges = ranges.slice().sort((a, b) => a.start - b.start);
+
+  let currentIndex = 0;
+  let currentNonspaceIndex =
+    currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
+
+  visit(tree, isText, (node, nodeIndex, parent) => {
+    const leadingSpaces = node.value.match(/^\s*/)[0];
+    const text = node.value.slice(leadingSpaces.length);
+
+    const endIndex = currentNonspaceIndex + text.length;
+    const expectedText = docsText.slice(currentNonspaceIndex, endIndex);
+
+    if (expectedText !== text) {
+      console.warn(
+        `Iterating text did not match expected!\n  Range: ${currentIndex}...${endIndex}\n  Text: "${node.value}"\n  Expected: "${docsText.slice(currentIndex, endIndex)}"`
+      );
+      return EXIT;
+    }
+
+    if (ranges[0] && ranges[0].start < endIndex) {
+      let range = ranges.shift();
+      const startInText = range.start - currentNonspaceIndex;
+      const rangeStart = leadingSpaces.length + startInText;
+
+      // If the range extends into another node chop it up and put the
+      // remainder back on the list of ranges to handle.
+      const overreach = range.start + range.length - endIndex;
+      if (overreach > 0) {
+        const remainder = { ...range, start: endIndex, length: overreach };
+        range = { ...range, length: endIndex - range.start };
+
+        const point = ranges.findIndex((r) => r.start >= remainder.start);
+        if (point < 0) {
+          ranges.push(remainder);
+        } else {
+          ranges.splice(point, 0, remainder);
+        }
+      }
+
+      visitor({ node, nodeIndex, parent, range, rangeStart });
+
+      if (ranges.length === 0) {
+        return EXIT;
+      } else {
+        // The next range could also be in this node, so re-visit it.
+        return [CONTINUE, nodeIndex];
+      }
+    } else {
+      currentIndex = endIndex;
+      currentNonspaceIndex =
+        currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
+    }
+  });
+}
+
+/**
+ * @typedef {object} GDocsRange
+ * @property {number} start
+ * @property {number} length
+ */
+
+/**
+ * Create a set of range objects to represent the location of suggested changes
+ * in the text based on data from a Slice Clip object.
+ *
+ * In the slice clip, ranges are represented by a large array, where each index
+ * indicates a location in the text. If the value is an array, it will be an
+ * array of suggestion IDs for suggestions that start (or continue) at that
+ * location in the text. If a currently open suggestion is not listed in the
+ * value, the location marks the end of that suggestion.
+ *
+ * For exampled, suggestion 'a' starts at index 2 and ends at 7; 'b' starts at
+ * index 2 and ends at 5:
+ *
+ *   [[], null, ['a', 'b'], null, null, ['a'], null, []]
+ *
+ * @param {any} sliceClip
+ * @param {"insertion"|"deletion"} type
+ * @returns {GDocsRange[]}
+ */
+function rangesForStyleSliceSuggestions(sliceClip, type) {
+  const text = sliceClip.resolved.dsl_spacers;
+  const locations = sliceClip.resolved[`dsl_suggested${type}s`].sgsl_sugg;
+
+  const ranges = [];
+  let openRanges = [];
+  for (let i = 0; i < locations.length; i++) {
+    let value = locations[i];
+    if (value != null) {
+      for (const range of openRanges) {
+        range.length = i - range.start;
+      }
+      openRanges = [];
+
+      for (const suggestionId of value) {
+        const range = { suggestionId, type, start: i, length: 0 };
+        ranges.push(range);
+        openRanges.push(range);
+      }
+    }
+  }
+
+  for (const range of openRanges) {
+    range.length = text.length - range.start;
+  }
+
+  return ranges;
+}
+
+/**
+ * Find suggested changes in the text and mark them with appropriate DOM nodes.
+ * Copying from Google Docs includes the suggestions in the text with no markup,
+ * so you can't tell what's been suggested for removal or insertion. However,
+ * the Slice Clip data includes the location of the suggestions.
+ * @param {RehypeNode} node
+ * @param {*} sliceClip
+ */
+function markSuggestions(node, sliceClip) {
+  if (!sliceClip) return;
+
+  const rawText = sliceClip.resolved.dsl_spacers;
+  const ranges = [
+    ...rangesForStyleSliceSuggestions(sliceClip, 'insertion'),
+    ...rangesForStyleSliceSuggestions(sliceClip, 'deletion'),
+  ];
+
+  forEachDocsRangeInTree(
+    rawText,
+    ranges,
+    node,
+    ({ node, nodeIndex, parent, range, rangeStart }) => {
+      const rangeEnd = rangeStart + range.length;
+      const textBefore = node.value.slice(0, rangeStart);
+      const textInside = node.value.slice(rangeStart, rangeEnd);
+      const textAfter = node.value.slice(rangeEnd);
+
+      const newNodes = [];
+      if (textBefore.length) {
+        newNodes.push({ type: 'text', value: textBefore });
+        // continueIndex += 1;
+      }
+      newNodes.push({
+        type: 'element',
+        tagName: range.type === 'insertion' ? 'ins' : 'del',
+        properties: { 'data-suggestion-id': range.suggestionId },
+        children: [{ type: 'text', value: textInside }],
+      });
+      if (textAfter.length) {
+        newNodes.push({ type: 'text', value: textAfter });
+      }
+      parent.children.splice(nodeIndex, 1, ...newNodes);
+    }
+  );
+}
+
+function formatSuggestions(tree, options) {
+  if (!['accept', 'reject'].includes(options.suggestions)) return;
+
+  visit(tree, isSuggestion, (node, index, parent) => {
+    if (
+      (options.suggestions === 'accept' && node.tagName === 'ins') ||
+      (options.suggestions === 'reject' && node.tagName === 'del')
+    ) {
+      parent.children.splice(index, 1, ...node.children);
+    } else {
+      parent.children.splice(index, 1);
+    }
+    return [CONTINUE, index];
+  });
+}
+
+/**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
  * might apply there, too; I haven’t looked into it).
  */
 export default function fixGoogleHtml() {
   return (tree, _file) => {
+    // Update the tree with data from a Google Docs Slice Clip.
+    markSuggestions(tree, _file.data.sliceClip);
+    fixInternalLinks(tree, _file.data.sliceClip);
+
+    // Generalized tree cleanup.
+    formatSuggestions(tree, _file.data.options);
     unInlineStyles(tree);
     createCodeBlocks(tree);
     moveSpaceOutsideSensitiveChildren(tree);
@@ -683,7 +874,7 @@ export default function fixGoogleHtml() {
     moveLinebreaksOutsideOfAnchors(tree);
     removeLineBreaksBeforeBlocks(tree);
     fixChecklists(tree);
-    fixInternalLinks(tree, _file.data.sliceClip);
+
     return tree;
   };
 }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -6,6 +6,11 @@ import { visitParents } from 'unist-util-visit-parents';
 import GithubSlugger from 'github-slugger';
 import debug from 'debug';
 import { resolveNodeStyle } from './css.js';
+import {
+  sliceClipText,
+  rangesForSuggestions,
+  replaceRangesInTree,
+} from './slice-clip.js';
 
 const log = debug('app:fix-google-html:debug');
 
@@ -72,7 +77,6 @@ const isSpaceSensitive = (node) =>
   node && spaceSensitiveElements.has(node.tagName);
 const isCell = (node) => node.tagName === 'th' || node.tagName === 'td';
 const isAnchor = (node) => node.tagName === 'a';
-const isText = (node) => node.type === 'text';
 const isSuggestion = (n) => n.properties?.['data-suggestion-id'] != null;
 
 const spaceAtStartPattern = /^(\s+)/;
@@ -664,127 +668,6 @@ function fixInternalLinks(node, sliceClip) {
 }
 
 /**
- * Visit each range of text as found in a HAST tree. You can replace or change
- * the node from within the visitor and it should continue to work.
- * @param {string} docsText
- * @param {GDocsRange[]} ranges
- * @param {RehypeNode} tree
- * @param {function} visitor
- */
-function forEachDocsRangeInTree(docsText, ranges, tree, visitor) {
-  if (ranges.length === 0) return;
-
-  ranges = ranges.slice().sort((a, b) => a.start - b.start);
-
-  let currentIndex = 0;
-  let currentNonspaceIndex =
-    currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
-
-  visit(tree, isText, (node, nodeIndex, parent) => {
-    const leadingSpaces = node.value.match(/^\s*/)[0];
-    const text = node.value.slice(leadingSpaces.length);
-
-    const endIndex = currentNonspaceIndex + text.length;
-    const expectedText = docsText.slice(currentNonspaceIndex, endIndex);
-
-    if (expectedText !== text) {
-      console.warn(
-        `Iterating text did not match expected!\n  Range: ${currentIndex}...${endIndex}\n  Text: "${node.value}"\n  Expected: "${docsText.slice(currentIndex, endIndex)}"`
-      );
-      return EXIT;
-    }
-
-    if (ranges[0] && ranges[0].start < endIndex) {
-      let range = ranges.shift();
-      const startInText = range.start - currentNonspaceIndex;
-      const rangeStart = leadingSpaces.length + startInText;
-
-      // If the range extends into another node chop it up and put the
-      // remainder back on the list of ranges to handle.
-      const overreach = range.start + range.length - endIndex;
-      if (overreach > 0) {
-        const remainder = { ...range, start: endIndex, length: overreach };
-        range = { ...range, length: endIndex - range.start };
-
-        const point = ranges.findIndex((r) => r.start >= remainder.start);
-        if (point < 0) {
-          ranges.push(remainder);
-        } else {
-          ranges.splice(point, 0, remainder);
-        }
-      }
-
-      visitor({ node, nodeIndex, parent, range, rangeStart });
-
-      if (ranges.length === 0) {
-        return EXIT;
-      } else {
-        // The next range could also be in this node, so re-visit it.
-        return [CONTINUE, nodeIndex];
-      }
-    } else {
-      currentIndex = endIndex;
-      currentNonspaceIndex =
-        currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
-    }
-  });
-}
-
-/**
- * @typedef {object} GDocsRange
- * @property {number} start
- * @property {number} length
- */
-
-/**
- * Create a set of range objects to represent the location of suggested changes
- * in the text based on data from a Slice Clip object.
- *
- * In the slice clip, ranges are represented by a large array, where each index
- * indicates a location in the text. If the value is an array, it will be an
- * array of suggestion IDs for suggestions that start (or continue) at that
- * location in the text. If a currently open suggestion is not listed in the
- * value, the location marks the end of that suggestion.
- *
- * For exampled, suggestion 'a' starts at index 2 and ends at 7; 'b' starts at
- * index 2 and ends at 5:
- *
- *   [[], null, ['a', 'b'], null, null, ['a'], null, []]
- *
- * @param {any} sliceClip
- * @param {"insertion"|"deletion"} type
- * @returns {GDocsRange[]}
- */
-function rangesForStyleSliceSuggestions(sliceClip, type) {
-  const text = sliceClip.resolved.dsl_spacers;
-  const locations = sliceClip.resolved[`dsl_suggested${type}s`].sgsl_sugg;
-
-  const ranges = [];
-  let openRanges = [];
-  for (let i = 0; i < locations.length; i++) {
-    let value = locations[i];
-    if (value != null) {
-      for (const range of openRanges) {
-        range.length = i - range.start;
-      }
-      openRanges = [];
-
-      for (const suggestionId of value) {
-        const range = { suggestionId, type, start: i, length: 0 };
-        ranges.push(range);
-        openRanges.push(range);
-      }
-    }
-  }
-
-  for (const range of openRanges) {
-    range.length = text.length - range.start;
-  }
-
-  return ranges;
-}
-
-/**
  * Find suggested changes in the text and mark them with appropriate DOM nodes.
  * Copying from Google Docs includes the suggestions in the text with no markup,
  * so you can't tell what's been suggested for removal or insertion. However,
@@ -795,39 +678,19 @@ function rangesForStyleSliceSuggestions(sliceClip, type) {
 function markSuggestions(node, sliceClip) {
   if (!sliceClip) return;
 
-  const rawText = sliceClip.resolved.dsl_spacers;
   const ranges = [
-    ...rangesForStyleSliceSuggestions(sliceClip, 'insertion'),
-    ...rangesForStyleSliceSuggestions(sliceClip, 'deletion'),
+    ...rangesForSuggestions(sliceClip, 'insertion'),
+    ...rangesForSuggestions(sliceClip, 'deletion'),
   ];
 
-  forEachDocsRangeInTree(
-    rawText,
-    ranges,
-    node,
-    ({ node, nodeIndex, parent, range, rangeStart }) => {
-      const rangeEnd = rangeStart + range.length;
-      const textBefore = node.value.slice(0, rangeStart);
-      const textInside = node.value.slice(rangeStart, rangeEnd);
-      const textAfter = node.value.slice(rangeEnd);
-
-      const newNodes = [];
-      if (textBefore.length) {
-        newNodes.push({ type: 'text', value: textBefore });
-        // continueIndex += 1;
-      }
-      newNodes.push({
-        type: 'element',
-        tagName: range.type === 'insertion' ? 'ins' : 'del',
-        properties: { 'data-suggestion-id': range.suggestionId },
-        children: [{ type: 'text', value: textInside }],
-      });
-      if (textAfter.length) {
-        newNodes.push({ type: 'text', value: textAfter });
-      }
-      parent.children.splice(nodeIndex, 1, ...newNodes);
-    }
-  );
+  replaceRangesInTree(sliceClipText(sliceClip), ranges, node, (range, text) => {
+    return {
+      type: 'element',
+      tagName: range.type === 'insertion' ? 'ins' : 'del',
+      properties: { 'data-suggestion-id': range.suggestionId },
+      children: [{ type: 'text', value: text }],
+    };
+  });
 }
 
 function formatSuggestions(tree, options) {

--- a/lib/slice-clip.js
+++ b/lib/slice-clip.js
@@ -1,0 +1,199 @@
+/**
+ * Tools for working with Google Docs Slice Clips (GDocs's internal pasteboard
+ * format).
+ */
+
+import { CONTINUE, EXIT, visit } from 'unist-util-visit';
+
+/**
+ * @typedef {object} GDocsRange
+ * @property {number} start
+ * @property {number} length
+ */
+
+const isText = (node) => node.type === 'text';
+
+/**
+ * Get the plain text of the slice clip.
+ * @param {any} sliceClip
+ * @returns {string}
+ */
+export function sliceClipText(sliceClip) {
+  return sliceClip.resolved.dsl_spacers;
+}
+
+/**
+ * Create a set of range objects to represent the location of suggested changes
+ * in the text based on data from a Slice Clip object.
+ *
+ * In the slice clip, ranges are represented by a large array, where each index
+ * indicates a location in the text. If the value is an array, it will be an
+ * array of suggestion IDs for suggestions that start (or continue) at that
+ * location in the text. If a currently open suggestion is not listed in the
+ * value, the location marks the end of that suggestion.
+ *
+ * For exampled, suggestion 'a' starts at index 2 and ends at 7; 'b' starts at
+ * index 2 and ends at 5:
+ *
+ *   [[], null, ['a', 'b'], null, null, ['a'], null, []]
+ *
+ * @param {any} sliceClip
+ * @param {"insertion"|"deletion"} type
+ * @returns {GDocsRange[]}
+ */
+export function rangesForSuggestions(sliceClip, type) {
+  const text = sliceClip.resolved.dsl_spacers;
+  const locations = sliceClip.resolved[`dsl_suggested${type}s`].sgsl_sugg;
+
+  const ranges = [];
+  let openRanges = [];
+  for (let i = 0; i < locations.length; i++) {
+    let value = locations[i];
+    if (value != null) {
+      for (const range of openRanges) {
+        range.length = i - range.start;
+      }
+      openRanges = [];
+
+      for (const suggestionId of value) {
+        const range = { suggestionId, type, start: i, length: 0 };
+        ranges.push(range);
+        openRanges.push(range);
+      }
+    }
+  }
+
+  for (const range of openRanges) {
+    range.length = text.length - range.start;
+  }
+
+  return ranges;
+}
+
+/**
+ * Visit each range of text as found in a HAST tree. You can replace or change
+ * the node from within the visitor and it should continue to work.
+ *
+ * WARNING: the overall *text content* of the tree must remain the same,
+ * otherwise work will stop early because the tree can no longer be matched
+ * up to the appropriate locations in the document. If you need to modify the
+ * text itself, wrap the text in a new node, and then visit those nodes in a
+ * second pass to update their text children.
+ *
+ * @param {string} docsText
+ * @param {GDocsRange[]} ranges
+ * @param {RehypeNode} tree
+ * @param {function} visitor
+ */
+export function visitRangesInTree(docsText, ranges, tree, visitor) {
+  if (ranges.length === 0) return;
+
+  ranges = ranges.slice().sort((a, b) => a.start - b.start);
+
+  // Line breaks and various space characters may be represented by elements
+  // in the HAST tree instead of being literally present as text. However,
+  // Non-space characters should always be preserved in HAST text nodes.
+  //
+  // Keep track of the location of the next non-space character so we can match
+  // the HAST tree against that rather than the literal text of the GDoc.
+  let currentIndex = 0;
+  let currentNonspaceIndex =
+    currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
+
+  visit(tree, isText, (node, nodeIndex, parent) => {
+    const leadingSpaces = node.value.match(/^\s*/)[0];
+    const text = node.value.slice(leadingSpaces.length);
+
+    const endIndex = currentNonspaceIndex + text.length;
+    const expectedText = docsText.slice(currentNonspaceIndex, endIndex);
+
+    if (expectedText !== text) {
+      console.warn(
+        `visitRangesInTree: stopping because node text did not match slice clip text!
+        Range: ${currentIndex}...${endIndex}
+        Text: "${node.value}"
+        Expected: "${docsText.slice(currentIndex, endIndex)}"`
+      );
+      return EXIT;
+    }
+
+    if (ranges[0] && ranges[0].start < endIndex) {
+      let range = ranges.shift();
+      let startInText = range.start - currentNonspaceIndex;
+      const rangeStart = Math.max(leadingSpaces.length + startInText, 0);
+      let rangeEnd = leadingSpaces.length + startInText + range.length;
+
+      // If the range extends into another node chop it up and put the
+      // remainder back on the list of ranges to handle.
+      const overreach = range.start + range.length - endIndex;
+      if (overreach > 0) {
+        rangeEnd = endIndex;
+
+        const remainder = { ...range, start: endIndex, length: overreach };
+        const point = ranges.findIndex((r) => r.start >= remainder.start);
+        if (point < 0) {
+          ranges.push(remainder);
+        } else {
+          ranges.splice(point, 0, remainder);
+        }
+      }
+
+      visitor({ node, nodeIndex, parent, range, rangeStart, rangeEnd });
+
+      if (ranges.length === 0) {
+        return EXIT;
+      } else {
+        // The next range could also be in this node, so re-visit it.
+        return [CONTINUE, nodeIndex];
+      }
+    } else {
+      currentIndex = endIndex;
+      currentNonspaceIndex =
+        currentIndex + docsText.slice(currentIndex).match(/^\s*/)[0].length;
+    }
+  });
+}
+
+/**
+ * Replace each range of text (from the original Google Doc) in a HAST tree
+ * with a new node.
+ *
+ * WARNING: the overall *text content* of the tree must remain the same,
+ * otherwise work will stop early because the tree can no longer be matched
+ * up to the appropriate locations in the document. If you need to modify the
+ * text itself, wrap the text in a new node, and then visit those nodes in a
+ * second pass to update their text children.
+ *
+ * @param {string} docsText
+ * @param {GDocsRange[]} ranges
+ * @param {RehypeNode} tree
+ * @param {(GDocsRange, string) => RehypeNode?} replacer
+ */
+export function replaceRangesInTree(docsText, ranges, node, replacer) {
+  visitRangesInTree(
+    docsText,
+    ranges,
+    node,
+    ({ node, nodeIndex, parent, range, rangeStart, rangeEnd }) => {
+      const textBefore = node.value.slice(0, rangeStart);
+      const textInside = node.value.slice(rangeStart, rangeEnd);
+      const textAfter = node.value.slice(rangeEnd);
+
+      const newNodes = [];
+      if (textBefore.length) {
+        newNodes.push({ type: 'text', value: textBefore });
+      }
+
+      const replacement = replacer(range, textInside);
+      if (replacement) {
+        newNodes.push(replacement);
+      }
+
+      if (textAfter.length) {
+        newNodes.push({ type: 'text', value: textAfter });
+      }
+
+      parent.children.splice(nodeIndex, 1, ...newNodes);
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   ],
   "license": "BSD-3-Clause",
-  "main": "index.js",
+  "main": "./lib-ui/index.js",
   "type": "module",
   "scripts": {
     "build": "mkdir -p dist && webpack",

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -26,6 +26,7 @@ const FIXTURES = {
   'linebreaks-at-the-end-of-links':
     '1YES2UjSQV16TOWhVT0fXoXvYTwrtdcKcO8kxr4-9yPs',
   'internal-links': '1Y4u0ZfjCLGB1nwg7aAw3f0QOD_ZAWak-AO-sbUtihco',
+  'suggestions': '1asWcI-BcMp5kivAupimw7Ndb0PiQ_l2dNVzVdGfdzKU',
 };
 const DOCUMENT_SLICE_CLIP_TYPE =
   'application/x-vnd.google-docs-document-slice-clip+wrapped';

--- a/test/fixtures/suggestions.copy.gdocsliceclip.json
+++ b/test/fixtures/suggestions.copy.gdocsliceclip.json
@@ -1,0 +1,1380 @@
+{
+  "cses": false,
+  "data": {
+    "autotext_content": {
+    },
+    "resolved": {
+      "dsl_drawingrevisionaccesstokenmap": {
+      },
+      "dsl_entitymap": {
+      },
+      "dsl_entitypositionmap": {
+      },
+      "dsl_entitytypemap": {
+      },
+      "dsl_metastyleslices": [
+        {
+          "stsl_styles": [
+            {
+              "ac_ct": null,
+              "ac_id": "",
+              "ac_ot": null,
+              "ac_sm": {
+                "asm_l": "",
+                "asm_rl": 0,
+                "asm_s": 0
+              },
+              "ac_type": null
+            }
+          ],
+          "stsl_type": "autocorrect"
+        },
+        {
+          "stsl_styles": [
+            {
+              "colc_icc": false
+            }
+          ],
+          "stsl_type": "collapsed_content"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cd_bgc": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "cd_u": false
+            }
+          ],
+          "stsl_type": "composing_decoration"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cr_c": false
+            }
+          ],
+          "stsl_type": "composing_region"
+        },
+        {
+          "stsl_styles": [
+            {
+              "dcs_cids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "draft_comment"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iwos_i": false
+            }
+          ],
+          "stsl_type": "ignore_word"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ocn_sttc": 0,
+              "ocn_tdsm": null,
+              "ocn_tfsm": null
+            }
+          ],
+          "stsl_type": "on_canvas_nudges"
+        },
+        {
+          "stsl_styles": [
+            {
+              "revdiff_a": "",
+              "revdiff_aid": "",
+              "revdiff_dt": 0
+            }
+          ],
+          "stsl_type": "revision_diff"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sc_id": "",
+              "sc_ow": null,
+              "sc_sl": null,
+              "sc_sm": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "sc_sugg": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vcs_c": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "vcs_id": ""
+            }
+          ],
+          "stsl_type": "voice_corrections"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vdss_id": "",
+              "vdss_p": null
+            }
+          ],
+          "stsl_type": "voice_dotted_span"
+        }
+      ],
+      "dsl_nestedmodelmap": {
+      },
+      "dsl_relateddocslices": {
+      },
+      "dsl_spacers": "This is a test of sugargested changes toin documents.\n\nThis tests some suggested changes that overlap formatting boundaries.\n\n",
+      "dsl_styleslices": [
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "autogen"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "cell"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "code_snippet"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "collapsed_heading"
+        },
+        {
+          "stsl_leading": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_leadingType": "column_sector",
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_trailingType": "column_sector",
+          "stsl_type": "column_sector"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cs_cids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "comment"
+        },
+        {
+          "stsl_styles": [
+            {
+              "das_a": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "doco_anchor"
+        },
+        {
+          "stsl_leading": {
+            "ds_b": {
+              "bg_c2": {
+                "clr_type": 0,
+                "hclr_color": null
+              }
+            },
+            "ds_ci": null,
+            "ds_df": {
+              "df_dm": 0
+            },
+            "ds_epfi": null,
+            "ds_ephi": null,
+            "ds_fi": null,
+            "ds_fpfi": null,
+            "ds_fphi": null,
+            "ds_fpo": false,
+            "ds_hi": null,
+            "ds_lhs": 1,
+            "ds_ln": {
+              "ln_lne": false,
+              "ln_lnm": 0
+            },
+            "ds_mb": 72,
+            "ds_mf": 36,
+            "ds_mh": 36,
+            "ds_ml": 72,
+            "ds_mr": 72,
+            "ds_mt": 72,
+            "ds_ph": 792,
+            "ds_pnsi": 1,
+            "ds_pw": 612,
+            "ds_rtd": "",
+            "ds_uephf": false,
+            "ds_ufphf": false,
+            "ds_ulhfl": false
+          },
+          "stsl_leadingType": "document",
+          "stsl_styles": [
+          ],
+          "stsl_type": "document"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation_function"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "esgs_s": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            }
+          },
+          "stsl_trailingType": "esignature_signers",
+          "stsl_type": "esignature_signers"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "field"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "footnote"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "headings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "horizontal_rule"
+        },
+        {
+          "stsl_styles": [
+            {
+              "isc_osh": null,
+              "isc_smer": true
+            }
+          ],
+          "stsl_type": "ignore_spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iws_iwids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "import_warnings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "lgs_l": "en"
+          },
+          "stsl_trailingType": "language",
+          "stsl_type": "language"
+        },
+        {
+          "stsl_styles": [
+            {
+              "lnks_link": null
+            }
+          ],
+          "stsl_type": "link"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            }
+          ],
+          "stsl_type": "list"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ms_id": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "markup"
+        },
+        {
+          "stsl_styles": [
+            {
+              "nrs_ei": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "named_range"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "paragraph"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "row"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sfs_sst": false
+            }
+          ],
+          "stsl_type": "suppress_feature"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "tbl"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": true,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            }
+          ],
+          "stsl_type": "text"
+        }
+      ],
+      "dsl_suggesteddeletions": {
+        "sgsl_sugg": [
+          [
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "suggest.7gspcz7ad4bk"
+          ],
+          null,
+          null,
+          null,
+          [
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "suggest.ui9ltbp9b5rc"
+          ],
+          null,
+          [
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "suggest.75p8n6576im4"
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+          ]
+        ]
+      },
+      "dsl_suggestedinsertions": {
+        "sgsl_sugg": [
+          [
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "suggest.4q4mbo93u071"
+          ],
+          null,
+          null,
+          [
+            "suggest.4q4mbo93u071",
+            "suggest.7gspcz7ad4bk"
+          ],
+          null,
+          [
+            "suggest.4q4mbo93u071"
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+          ],
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "suggest.ui9ltbp9b5rc"
+          ],
+          null,
+          [
+          ]
+        ]
+      }
+    }
+  },
+  "dct": "kix",
+  "dih": 481043762,
+  "ds": false,
+  "edi": "<random>",
+  "edrk": "<random>",
+  "sm": "other"
+}

--- a/test/fixtures/suggestions.copy.html
+++ b/test/fixtures/suggestions.copy.html
@@ -1,0 +1,20 @@
+<span id="docs-internal-guid-dddddddd-dddd-dddd-dddd-123456789abc">
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			This is a test of sugargested changes toin documents.
+		</span>
+	</p>
+	<br>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			This tests some 
+		</span>
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-weight: 700; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			suggested changes
+		</span>
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			 that overlap formatting boundaries.
+		</span>
+	</p>
+	<br>
+</span>

--- a/test/fixtures/suggestions.expected.accept.md
+++ b/test/fixtures/suggestions.expected.accept.md
@@ -1,0 +1,3 @@
+This is a test of sugared changes to documents.
+
+This tests **changes** that overlap formatting boundaries.

--- a/test/fixtures/suggestions.expected.md
+++ b/test/fixtures/suggestions.expected.md
@@ -1,3 +1,3 @@
-This is a test of <ins>sug<ins>ar</ins>~~gest~~ed</ins> changes <ins>to</ins>~~in~~ documents.
+This is a test of changes in documents.
 
-This tests ~~some~~ **~~suggested~~ changes** that overlap formatting boundaries.
+This tests some **suggested changes** that overlap formatting boundaries.

--- a/test/fixtures/suggestions.expected.md
+++ b/test/fixtures/suggestions.expected.md
@@ -1,0 +1,3 @@
+This is a test of <ins>sug<ins>ar</ins>~~gest~~ed</ins> changes <ins>to</ins>~~in~~ documents.
+
+This tests ~~some~~ **~~suggested~~ changes** that overlap formatting boundaries.

--- a/test/fixtures/suggestions.expected.show.md
+++ b/test/fixtures/suggestions.expected.show.md
@@ -1,0 +1,3 @@
+This is a test of <ins>sug<ins>ar</ins>~~gest~~ed</ins> changes <ins>to</ins>~~in~~ documents.
+
+This tests ~~some~~ **~~suggested~~ changes** that overlap formatting boundaries.

--- a/test/fixtures/suggestions.export.html
+++ b/test/fixtures/suggestions.export.html
@@ -1,0 +1,198 @@
+<html>
+	<head>
+		<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+		<style type="text/css">
+			ol{
+	margin:0;
+	padding:0
+}
+table td,table th{
+	padding:0
+}
+.title{
+	padding-top:0pt;
+	color:#000000;
+	font-size:26pt;
+	padding-bottom:3pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.subtitle{
+	padding-top:0pt;
+	color:#666666;
+	font-size:15pt;
+	padding-bottom:16pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+li{
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+p{
+	margin:0;
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+h1{
+	padding-top:20pt;
+	color:#000000;
+	font-size:20pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h2{
+	padding-top:18pt;
+	color:#000000;
+	font-size:16pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h3{
+	padding-top:16pt;
+	color:#434343;
+	font-size:14pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h4{
+	padding-top:14pt;
+	color:#666666;
+	font-size:12pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h5{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h6{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	font-style:italic;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c1{
+	background-color:#ffffff;
+	max-width:468pt;
+	padding:72pt 72pt 72pt 72pt
+}
+.c2{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c3{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c4{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	orphans:2;
+	widows:2;
+	text-align:left;
+	height:11pt
+}
+.c5{
+	font-weight:700
+}
+
+		</style>
+	</head>
+	<body class="c1 doc-content">
+		<p class="c2">
+			<span>
+				This is a test of 
+			</span>
+			<span>
+				changes 
+			</span>
+			<span>
+				in
+			</span>
+			<span class="c3">
+				&nbsp;documents.
+			</span>
+		</p>
+		<p class="c4">
+			<span class="c3">
+			</span>
+		</p>
+		<p class="c2">
+			<span>
+				This tests 
+			</span>
+			<span>
+				some 
+			</span>
+			<span class="c5">
+				suggested 
+			</span>
+			<span class="c5">
+				changes
+			</span>
+			<span class="c3">
+				&nbsp;that overlap formatting boundaries.
+			</span>
+		</p>
+		<p class="c4">
+			<span class="c3">
+			</span>
+		</p>
+	</body>
+</html>

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -50,6 +50,9 @@ describe('convert', () => {
   createFixtureTest('internal-links', { type: 'copy' });
   createFixtureTest('internal-links', { type: 'export', skip: true });
 
+  createFixtureTest('suggestions', { type: 'copy' });
+  createFixtureTest('suggestions', { type: 'export', skip: true });
+
   // At current, it doesn't seem like this situation can happen in a Google Doc,
   // but it's worth supporting just in case things change or users want to
   // convert more arbitrary HTML.

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -3,18 +3,26 @@ import { convertDocsHtmlToMarkdown } from '../../lib/convert.js';
 import { loadFixture } from '../support/fixtures.js';
 
 describe('convert', () => {
-  function createFixtureTest(name, { type, skip = false }) {
+  function createFixtureTest(
+    name,
+    { type, skip = false, options = null, variation = '' }
+  ) {
     const test = skip ? it.skip : it;
 
-    test(`converts ${name} (${type})`, async () => {
+    test(`converts ${name}${variation} (${type})`, async () => {
       const input = await loadFixture(`${name}.${type}.html`);
       const inputSliceClip =
         type === 'copy'
           ? await loadFixture(`${name}.${type}.gdocsliceclip.json`)
           : null;
-      const expected = await loadFixture(`${name}.expected.md`);
+      const expected = await loadFixture(`${name}.expected${variation}.md`);
 
-      const md = await convertDocsHtmlToMarkdown(input, inputSliceClip);
+      const md = await convertDocsHtmlToMarkdown(
+        input,
+        inputSliceClip,
+        options
+      );
+
       expect(md).toEqual(expected);
     });
   }
@@ -50,7 +58,20 @@ describe('convert', () => {
   createFixtureTest('internal-links', { type: 'copy' });
   createFixtureTest('internal-links', { type: 'export', skip: true });
 
-  createFixtureTest('suggestions', { type: 'copy' });
+  createFixtureTest('suggestions', {
+    type: 'copy',
+    options: { suggestions: 'reject' },
+  });
+  createFixtureTest('suggestions', {
+    type: 'copy',
+    variation: '.show',
+    options: { suggestions: 'show' },
+  });
+  createFixtureTest('suggestions', {
+    type: 'copy',
+    variation: '.accept',
+    options: { suggestions: 'accept' },
+  });
   createFixtureTest('suggestions', { type: 'export', skip: true });
 
   // At current, it doesn't seem like this situation can happen in a Google Doc,

--- a/wdio.conf.e2e.js
+++ b/wdio.conf.e2e.js
@@ -4,6 +4,11 @@ import WebpackDevServerService from './test/support/wdio-webpack-dev-server.js';
 export const config = {
   ...base,
   runner: 'local',
+
+  // Safari seems to have particular issues with automating user interaction in
+  // parallel with other browsers, so only run one browser at a time for e2e.
+  maxInstances: 1,
+
   specs: ['./test/e2e/**/*.test.js'],
   baseUrl: WebpackDevServerService.getServerUrl(),
   services: [...base.services, [WebpackDevServerService, {}]],

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -7,7 +7,7 @@ const nodeEnv = process.env.NODE_ENV || 'development';
 const isProduction = nodeEnv.toLocaleLowerCase() === 'production';
 
 module.exports = {
-  entry: './index.js',
+  entry: './lib-ui/index.js',
   mode: isProduction ? 'production' : 'development',
   devtool: isProduction ? 'source-map' : 'inline-source-map',
   output: {


### PR DESCRIPTION
Fixes #194.

This adds intentional handling for suggested changes. Before, if there were suggestions in the text, we'd show them in a totally undifferentiated way right next to the original text, which could make things appear totally garbled.

For example, this test doc:

![Screenshot Google Doc with suggestions](https://github.com/user-attachments/assets/2c984975-0dc8-4e4f-b9c6-df405e22feb9)

Gets this markdown output:

```markdown
This is a test of sugargested changes toin documents.

This tests some **suggested changes** that overlap formatting boundaries.
```

This is because the HTML that Google Docs puts on the pasteboard doesn’t have any info about the suggestions and shows both the suggested insertions and the text that would be deleted right alongside each other. However, the Slice Clip data *does* have info about the suggestions, so we use that to figure out where insertions and deletions go in the text. Unfortunately, that means this doesn’t really work in Safari, since it doesn’t allow one origin (`gdoc2md.com`) to access pasteboard data with a non-standard format from a different origin (`docs.google.com`), and therefore doesn’t give us the Slice Clip data. But it at least works in Firefox and (most?) Chromium-based browsers.

A bunch of other little changes came along for the ride here, since this was pretty complex:

- The work of walking through the tree and finding ranges of text is handled in an abstract way by `forEachDocsRangeInTree()`. We ought to be able to use this to handle #134 in a followup PR. 🎉 

- This PR makes it clear @trustedtomato’s original approach from #96, where data from the slice clip was combined with the GDocs HTML *before* putting it in the input area, rather than during conversion, was correct, and my objections to it were definitely wrong. I’d been thinking about that a bit, and coming back to this project for the first time in a bit with fresh eyes has helped clarify that. You can see the problems the current architecture imposes here, where you cannot touch up any text before a suggestion otherwise the whole things completely breaks.

    That said, changing that architecture is a huge refactor, and it’ll have to come in a followup PR. But it definitely should be done.

    For now, I’ve grouped the conversion steps that combine data from the slice clip with the tree together and put them before all the other conversion steps. That should make their difference more clear and make them easier to move later.

- I don’t think there’s a clear answer for how suggestions should be handled, so I wound up finally adding settings here (so this partially gets at #133). You can show the suggestions with insertion and deletion markers in markdown, “accept” (convert the document as it would be with the suggestions), or “reject” them (convert the document as it was without the suggestions). Rejection is the default.

    I put in placeholder defaults for the settings we obviously out to have around heading IDs, but will actually implement them in a separate PR.

- Adding settings imposed enough complexity that I decided to split the UI-related JS into multiple modules and move them into a new `lib-ui` directory.

- This probably needs a second pass and maybe some light cleanup. But it should work OK.