### PR TITLE
Support links to bookmarks in the document

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -75,6 +75,17 @@ const processor = unified()
       h4: headingWithId,
       h5: headingWithId,
       h6: headingWithId,
+
+      // The default `<a>` handler swallows link *targets*. We need to preserve
+      // them so bookmarks for intra-document links work.
+      a(state, node, _parent) {
+        const anchorName = node.properties.id || node.properties.name;
+        if (anchorName && !node.properties.href) {
+          return [{ type: 'html', value: `<a id="${anchorName}"></a>` }];
+        } else {
+          return defaultHandlers['a'](state, node);
+        }
+      },
     },
   })
   .use(remarkGfm)

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -9,6 +9,7 @@ import { resolveNodeStyle } from './css.js';
 import {
   sliceClipText,
   rangesForSuggestions,
+  getBookmarks,
   replaceRangesInTree,
 } from './slice-clip.js';
 
@@ -693,6 +694,12 @@ function markSuggestions(node, sliceClip) {
   });
 }
 
+/**
+ * Update suggested changes in the tree so that they render as if they were
+ * accepted or rejected according to the passed in options.
+ * @param {RehypeNode} tree
+ * @param {{ suggestions: string }} options
+ */
 function formatSuggestions(tree, options) {
   if (!['accept', 'reject'].includes(options.suggestions)) return;
 
@@ -710,6 +717,45 @@ function formatSuggestions(tree, options) {
 }
 
 /**
+ * Find bookmarks that are the targets for intra-document links and place them
+ * in the tree. Bookmarks are missing from the copied HTML, but are present in
+ * the slice clip data.
+ * @param {RehypeNode} tree
+ * @param {any} sliceClip
+ */
+function placeBookmarks(tree, sliceClip) {
+  const { ids, ranges } = getBookmarks(sliceClip);
+  if (ranges.length === 0) return;
+
+  // Insert anchors where the bookmarks should be.
+  replaceRangesInTree(sliceClipText(sliceClip), ranges, tree, (range) => {
+    return {
+      type: 'element',
+      tagName: 'a',
+      properties: { name: range.bookmark },
+      children: [],
+    };
+  });
+
+  // Update the links to point to the new anchors.
+  visit(tree, isAnchor, (node, _index, _parent) => {
+    let url;
+    try {
+      url = new URL(node.properties.href);
+    } catch (_error) {
+      return;
+    }
+
+    if (url.host === 'docs.google.com') {
+      const id = url.hash.match(/^#bookmark=([a-z0-9.]+)$/)?.[1];
+      if (ids.has(id)) {
+        node.properties.href = `#${id}`;
+      }
+    }
+  });
+}
+
+/**
  * A rehype plugin to clean up the HTML of a Google Doc. .This applies to the
  * live HTML of Doc, as when you copy and paste it; not *exported* HTML (it
  * might apply there, too; I haven’t looked into it).
@@ -719,6 +765,7 @@ export default function fixGoogleHtml() {
     // Update the tree with data from a Google Docs Slice Clip.
     markSuggestions(tree, _file.data.sliceClip);
     fixInternalLinks(tree, _file.data.sliceClip);
+    placeBookmarks(tree, _file.data.sliceClip);
 
     // Generalized tree cleanup.
     formatSuggestions(tree, _file.data.options);

--- a/lib/slice-clip.js
+++ b/lib/slice-clip.js
@@ -71,6 +71,30 @@ export function rangesForSuggestions(sliceClip, type) {
 }
 
 /**
+ * Get the IDs and locations of all the bookmarks in a slice clip.
+ * @param {any} sliceClip
+ * @returns {{ ids: Set<string>, ranges: GDocsRange[] }}
+ */
+export function getBookmarks(sliceClip) {
+  const ids = new Set();
+  const ranges = [];
+  const positionMap = sliceClip?.resolved?.dsl_entitypositionmap?.bookmark;
+
+  if (positionMap) {
+    for (let i = 0; i < positionMap.length; i++) {
+      if (positionMap[i] != null) {
+        for (const id of positionMap[i]) {
+          ids.add(id);
+          ranges.push({ bookmark: id, start: i, length: 0 });
+        }
+      }
+    }
+  }
+
+  return { ids, ranges };
+}
+
+/**
  * Visit each range of text as found in a HAST tree. You can replace or change
  * the node from within the visitor and it should continue to work.
  *

--- a/test/fixtures/internal-links.expected.md
+++ b/test/fixtures/internal-links.expected.md
@@ -2,16 +2,16 @@ This is a test of intra-document links to headings and bookmarks.
 
 [Link to the first heading.](#first-heading)
 
-[Link to the first bookmark.](https://docs.google.com/document/d/1Y4u0ZfjCLGB1nwg7aAw3f0QOD_ZAWak-AO-sbUtihco/edit#bookmark=id.qbdatvy5x87)
+[Link to the first bookmark.](#id.qbdatvy5x87)
 
-[Link to the second bookmark.](https://docs.google.com/document/d/1Y4u0ZfjCLGB1nwg7aAw3f0QOD_ZAWak-AO-sbUtihco/edit#bookmark=id.gg8i29488moj)
+[Link to the second bookmark.](#id.gg8i29488moj)
 
 
 # First heading<a id="first-heading"></a>
 
 Hello World.
 
-First bookmark.
+<a id="id.qbdatvy5x87"></a>First bookmark.
 
 
 ## Second heading<a id="second-heading"></a>
@@ -23,4 +23,4 @@ Hello World.
 
 The heading name is intentionally repeated to ensure we get different IDs.
 
-Second bookmark.
+<a id="id.gg8i29488moj"></a>Second bookmark.


### PR DESCRIPTION
We already support links to headings in the document, but links to bookmarks have been hard because the GDocs HTML format does not include the locations of the bookmarks. In #213 we added tooling that makes it much easier to figure out where in the text objects from the Slice Clip format belong, so now we can put the bookmarks in the right place, which then allows us to link to them.

Fixes #134.