### PR TITLE
Keep heading IDs in docs w/ titles, empty headings

### DIFF
--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -10,6 +10,7 @@ import {
   sliceClipText,
   rangesForSuggestions,
   getBookmarks,
+  getHeadings,
   replaceRangesInTree,
 } from './slice-clip.js';
 
@@ -603,18 +604,8 @@ function getTextContent(node) {
 function fixInternalLinks(node, sliceClip) {
   if (!sliceClip) return;
 
-  let internalHeadings;
-  try {
-    internalHeadings = sliceClip.resolved.dsl_styleslices
-      .find((styleslice) => styleslice.stsl_type === 'paragraph')
-      .stsl_styles.filter((style) => style?.ps_hdid)
-      .map((heading) => ({ level: heading.ps_hd, id: heading.ps_hdid }));
-  } catch (error) {
-    console.error('Error extracting headings from GDocs slice clip:', error);
-  }
-
-  // Nothing to do if there were no headings!
-  if (!internalHeadings?.length) return;
+  const sliceClipHeadings = getHeadings(sliceClip).filter((h) => h.text);
+  if (!sliceClipHeadings.length) return;
 
   const headings = [];
   visit(
@@ -629,7 +620,7 @@ function fixInternalLinks(node, sliceClip) {
   if (
     !headings.every(
       (heading, index) =>
-        heading.tagName.toLowerCase() === `h${internalHeadings?.[index]?.level}`
+        heading.tagName.toLowerCase() === `h${sliceClipHeadings[index]?.level}`
     )
   ) {
     console.warn(
@@ -642,7 +633,7 @@ function fixInternalLinks(node, sliceClip) {
   const slugger = new GithubSlugger();
   const headingIdMap = new Map();
   headings.forEach((heading, index) => {
-    const internalHeading = internalHeadings[index];
+    const internalHeading = sliceClipHeadings[index];
     const newId = slugger.slug(getTextContent(heading));
     heading.properties.id = newId;
     headingIdMap.set(internalHeading.id, newId);

--- a/lib/slice-clip.js
+++ b/lib/slice-clip.js
@@ -13,6 +13,12 @@ import { CONTINUE, EXIT, visit } from 'unist-util-visit';
 
 const isText = (node) => node.type === 'text';
 
+function getStyles(sliceClip, styleType) {
+  return sliceClip.resolved.dsl_styleslices.find(
+    (slice) => slice.stsl_type === styleType
+  ).stsl_styles;
+}
+
 /**
  * Get the plain text of the slice clip.
  * @param {any} sliceClip
@@ -68,6 +74,51 @@ export function rangesForSuggestions(sliceClip, type) {
   }
 
   return ranges;
+}
+
+/**
+ * @typedef {object} HeadingInfo
+ * @property {number} start
+ * @property {number} end
+ * @property {string} text
+ * @property {number} level
+ * @property {string} id
+ */
+
+/**
+ * Get information about all the headings in the slice clip.
+ * @param {any} sliceClip
+ * @returns {HeadingInfo[]}
+ */
+export function getHeadings(sliceClip) {
+  const headings = [];
+  const paragraphStyles = getStyles(sliceClip, 'paragraph');
+
+  // Paragraph styles have objects at the index of the paragraph's *end*.
+  // It appears all text is expected to be in a paragraph, so the end of one
+  // implicitly begins another.
+  let current = { start: 0 };
+  for (let i = 0; i < paragraphStyles.length; i++) {
+    const style = paragraphStyles[i];
+    if (style == null) continue;
+
+    // Titles have `ps_hd = 100`, so confine ouselves to normal heading levels.
+    if (style.ps_hdid && style.ps_hd < 7) {
+      const text = sliceClipText(sliceClip).slice(current.start, i);
+      headings.push({
+        ...current,
+        end: i,
+        text,
+        level: style.ps_hd,
+        id: style.ps_hdid,
+      });
+    }
+
+    // The next character after a paragraph is a line break; skip it.
+    current = { start: i + 1 };
+  }
+
+  return headings;
 }
 
 /**

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -27,6 +27,7 @@ const FIXTURES = {
     '1YES2UjSQV16TOWhVT0fXoXvYTwrtdcKcO8kxr4-9yPs',
   'internal-links': '1Y4u0ZfjCLGB1nwg7aAw3f0QOD_ZAWak-AO-sbUtihco',
   'suggestions': '1asWcI-BcMp5kivAupimw7Ndb0PiQ_l2dNVzVdGfdzKU',
+  'titles-and-empty-headings': '1L3f1BAaB80Wtou46u4tv2qcQNFJ48GAkpkf6fM5Dl_c',
 };
 const DOCUMENT_SLICE_CLIP_TYPE =
   'application/x-vnd.google-docs-document-slice-clip+wrapped';

--- a/test/fixtures/titles-and-empty-headings.copy.gdocsliceclip.json
+++ b/test/fixtures/titles-and-empty-headings.copy.gdocsliceclip.json
@@ -1,0 +1,1716 @@
+{
+  "cses": false,
+  "data": {
+    "autotext_content": {
+    },
+    "resolved": {
+      "dsl_drawingrevisionaccesstokenmap": {
+      },
+      "dsl_entitymap": {
+      },
+      "dsl_entitypositionmap": {
+      },
+      "dsl_entitytypemap": {
+      },
+      "dsl_metastyleslices": [
+        {
+          "stsl_styles": [
+            {
+              "ac_ct": null,
+              "ac_id": "",
+              "ac_ot": null,
+              "ac_sm": {
+                "asm_l": "",
+                "asm_rl": 0,
+                "asm_s": 0
+              },
+              "ac_type": null
+            }
+          ],
+          "stsl_type": "autocorrect"
+        },
+        {
+          "stsl_styles": [
+            {
+              "colc_icc": false
+            }
+          ],
+          "stsl_type": "collapsed_content"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cd_bgc": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "cd_u": false
+            }
+          ],
+          "stsl_type": "composing_decoration"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cr_c": false
+            }
+          ],
+          "stsl_type": "composing_region"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iwos_i": false
+            }
+          ],
+          "stsl_type": "ignore_word"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ocn_sttc": 0,
+              "ocn_tdsm": null,
+              "ocn_tfsm": null
+            }
+          ],
+          "stsl_type": "on_canvas_nudges"
+        },
+        {
+          "stsl_styles": [
+            {
+              "revdiff_a": "",
+              "revdiff_aid": "",
+              "revdiff_dt": 0
+            }
+          ],
+          "stsl_type": "revision_diff"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sc_id": "",
+              "sc_ow": null,
+              "sc_sl": null,
+              "sc_sm": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "sc_sugg": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vcs_c": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "vcs_id": ""
+            }
+          ],
+          "stsl_type": "voice_corrections"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vdss_id": "",
+              "vdss_p": null
+            }
+          ],
+          "stsl_type": "voice_dotted_span"
+        }
+      ],
+      "dsl_nestedmodelmap": {
+      },
+      "dsl_relateddocslices": {
+      },
+      "dsl_spacers": "This is a test of handling titles and empty headings. They should not break heading links.\n\nDocument title!\nNormal text. The next line is an empty heading.\n\nNon-empty Heading\nNormal text 2.\n",
+      "dsl_styleslices": [
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "autogen"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "cell"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "code_snippet"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "collapsed_heading"
+        },
+        {
+          "stsl_leading": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_leadingType": "column_sector",
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_trailingType": "column_sector",
+          "stsl_type": "column_sector"
+        },
+        {
+          "stsl_leading": {
+            "ds_b": {
+              "bg_c2": {
+                "clr_type": 0,
+                "hclr_color": null
+              }
+            },
+            "ds_ci": null,
+            "ds_df": {
+              "df_dm": 0
+            },
+            "ds_epfi": null,
+            "ds_ephi": null,
+            "ds_fi": null,
+            "ds_fpfi": null,
+            "ds_fphi": null,
+            "ds_fpo": false,
+            "ds_hi": null,
+            "ds_lhs": 1,
+            "ds_ln": {
+              "ln_lne": false,
+              "ln_lnm": 0
+            },
+            "ds_mb": 72,
+            "ds_mf": 36,
+            "ds_mh": 36,
+            "ds_ml": 72,
+            "ds_mr": 72,
+            "ds_mt": 72,
+            "ds_ph": 792,
+            "ds_pnsi": 1,
+            "ds_pw": 612,
+            "ds_rtd": "",
+            "ds_uephf": false,
+            "ds_ufphf": false,
+            "ds_ulhfl": false
+          },
+          "stsl_leadingType": "document",
+          "stsl_styles": [
+          ],
+          "stsl_type": "document"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation_function"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "esgs_s": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            }
+          },
+          "stsl_trailingType": "esignature_signers",
+          "stsl_type": "esignature_signers"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "field"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "footnote"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "headings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "horizontal_rule"
+        },
+        {
+          "stsl_styles": [
+            {
+              "isc_osh": null,
+              "isc_smer": true
+            }
+          ],
+          "stsl_type": "ignore_spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iws_iwids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "import_warnings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "lgs_l": "en"
+          },
+          "stsl_trailingType": "language",
+          "stsl_type": "language"
+        },
+        {
+          "stsl_styles": [
+            {
+              "lnks_link": null
+            }
+          ],
+          "stsl_type": "link"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            }
+          ],
+          "stsl_type": "list"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ms_id": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "markup"
+        },
+        {
+          "stsl_styles": [
+            {
+              "nrs_ei": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "named_range"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 100,
+              "ps_hdid": "h.4zf4e326raqp",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": true,
+              "ps_klt_i": false,
+              "ps_kwn": true,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 3,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 1,
+              "ps_hdid": "h.lqer93j1khtb",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": true,
+              "ps_klt_i": false,
+              "ps_kwn": true,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 6,
+              "ps_sa_i": false,
+              "ps_sb": 20,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": true,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 1,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "paragraph"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "row"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sfs_sst": false
+            }
+          ],
+          "stsl_type": "suppress_feature"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "tbl"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 26,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 20,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "Arial",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            }
+          ],
+          "stsl_type": "text"
+        }
+      ],
+      "dsl_suggesteddeletions": {
+        "sgsl_sugg": [
+        ]
+      },
+      "dsl_suggestedinsertions": {
+        "sgsl_sugg": [
+        ]
+      }
+    }
+  },
+  "dct": "kix",
+  "dih": 2639747270,
+  "ds": false,
+  "edi": "<random>",
+  "edrk": "<random>",
+  "sm": "other"
+}

--- a/test/fixtures/titles-and-empty-headings.copy.html
+++ b/test/fixtures/titles-and-empty-headings.copy.html
@@ -1,0 +1,34 @@
+<span id="docs-internal-guid-dddddddd-dddd-dddd-dddd-123456789abc">
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			This is a test of handling titles and empty headings. They should not break heading links.
+		</span>
+	</p>
+	<br>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:3pt;">
+		<span style="font-size: 26pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Document title!
+		</span>
+	</p>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Normal text. The next line is an empty heading.
+		</span>
+	</p>
+	<br>
+	<h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;">
+		<span style="font-size: 20pt; font-family: Arial, sans-serif; font-weight: 400; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Non-empty Heading
+		</span>
+	</h1>
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			Normal text 2.
+		</span>
+	</p>
+	<div>
+		<span style="font-size: 11pt; font-family: Arial, sans-serif; font-variant-numeric: normal; font-variant-east-asian: normal; font-variant-alternates: normal; font-variant-position: normal; vertical-align: baseline; white-space-collapse: preserve;">
+			<br>
+		</span>
+	</div>
+</span>

--- a/test/fixtures/titles-and-empty-headings.expected.md
+++ b/test/fixtures/titles-and-empty-headings.expected.md
@@ -1,0 +1,10 @@
+This is a test of handling titles and empty headings. They should not break heading links.
+
+Document title!
+
+Normal text. The next line is an empty heading.
+
+
+# Non-empty Heading<a id="non-empty-heading"></a>
+
+Normal text 2.

--- a/test/fixtures/titles-and-empty-headings.export.html
+++ b/test/fixtures/titles-and-empty-headings.export.html
@@ -1,0 +1,219 @@
+<html>
+	<head>
+		<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+		<style type="text/css">
+			ol{
+	margin:0;
+	padding:0
+}
+table td,table th{
+	padding:0
+}
+.title{
+	padding-top:0pt;
+	color:#000000;
+	font-size:26pt;
+	padding-bottom:3pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.subtitle{
+	padding-top:0pt;
+	color:#666666;
+	font-size:15pt;
+	padding-bottom:16pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+li{
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+p{
+	margin:0;
+	color:#000000;
+	font-size:11pt;
+	font-family:"Arial"
+}
+h1{
+	padding-top:20pt;
+	color:#000000;
+	font-size:20pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h2{
+	padding-top:18pt;
+	color:#000000;
+	font-size:16pt;
+	padding-bottom:6pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h3{
+	padding-top:16pt;
+	color:#434343;
+	font-size:14pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h4{
+	padding-top:14pt;
+	color:#666666;
+	font-size:12pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h5{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+h6{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:4pt;
+	font-family:"Arial";
+	line-height:1.15;
+	page-break-after:avoid;
+	font-style:italic;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c1{
+	background-color:#ffffff;
+	max-width:468pt;
+	padding:72pt 72pt 72pt 72pt
+}
+.c2{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c3{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c4{
+	height:11pt
+}
+.c5{
+	padding-top:0pt;
+	padding-bottom:3pt;
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c6{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:26pt;
+	font-family:"Arial";
+	font-style:normal
+}
+.c7{
+	padding-top:20pt;
+	padding-bottom:6pt;
+	line-height:1.15;
+	page-break-after:avoid;
+	orphans:2;
+	widows:2;
+	text-align:left
+}
+.c8{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:20pt;
+	font-family:"Arial";
+	font-style:normal
+}
+
+		</style>
+	</head>
+	<body class="c1 doc-content">
+		<p class="c2">
+			<span class="c3">
+				This is a test of handling titles and empty headings. They should not break heading links.
+			</span>
+		</p>
+		<p class="c2 c4">
+			<span class="c3">
+			</span>
+		</p>
+		<p class="c5 title" id="h.4zf4e326raqp">
+			<span class="c6">
+				Document title!
+			</span>
+		</p>
+		<p class="c2">
+			<span class="c3">
+				Normal text. The next line is an empty heading.
+			</span>
+		</p>
+		<p class="c2 c4">
+			<span class="c3">
+			</span>
+		</p>
+		<h1 class="c7" id="h.lqer93j1khtb">
+			<span class="c8">
+				Non-empty Heading
+			</span>
+		</h1>
+		<p class="c2">
+			<span class="c3">
+				Normal text 2.
+			</span>
+		</p>
+	</body>
+</html>

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -74,6 +74,12 @@ describe('convert', () => {
   });
   createFixtureTest('suggestions', { type: 'export', skip: true });
 
+  createFixtureTest('titles-and-empty-headings', { type: 'copy' });
+  createFixtureTest('titles-and-empty-headings', {
+    type: 'export',
+    skip: true,
+  });
+
   // At current, it doesn't seem like this situation can happen in a Google Doc,
   // but it's worth supporting just in case things change or users want to
   // convert more arbitrary HTML.


### PR DESCRIPTION
The previous heading finding algorithm for slice clips wound up with mismatches if a document included a title (which is a heading level 100 in the slice clip, but plain text in HTML) or headings that are empty (definitely a weird case; these don't show up at all in the HTML). This implements a new, more strict algorithm that also surfaces more info about the headings.

Fixes #215.