### PR TITLE
Remove browser-added fragment markers from clipboard content

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This project is open source, and gets better with the hard work and collaboratio
 | [💻](# "Code") | [Peter Law](https://github.com/PeterJCLaw) |
 | [📖](# "Documentation") [🚇](# "Infrastructure") | [Marcin Rataj](https://github.com/lidel) |
 | [💻](# "Code") | [Ben Sheldon](https://github.com/bensheldon) |
+| [💻](# "Code") | [Jace Sleeman](https://github.com/TheRealPerson98) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 (For a key to the contribution emoji or more info on this format, check out [“All Contributors.”](https://allcontributors.org/docs/en/emoji-key))

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -825,6 +825,22 @@ function unwrapClipboardHtmlEnvelope(tree) {
 }
 
 /**
+ * Remove fragment markers that browsers add to clipboard content.
+ * @param {HastNodes} node Fix the tree below this node
+ */
+function removeFragmentMarkers(node) {
+  visit(node, (node) => {
+    if (node.type === 'comment' && 
+        (node.value === 'StartFragment' || node.value === 'EndFragment')) {
+      return node;
+    }
+  }, (node, index, parent) => {
+    parent.children.splice(index, 1);
+    return index;
+  });
+}
+
+/**
  * A Unified plugin that adds metadata from a Google Docs "Slice Clip" object
  * into the HTML/HAST tree of a pasted Google Doc.
  *
@@ -863,6 +879,7 @@ export function cleanGoogleHtml() {
     moveLinebreaksOutsideOfAnchors(tree);
     removeLineBreaksBeforeBlocks(tree);
     fixChecklists(tree);
+    removeFragmentMarkers(tree);
 
     return tree;
   };

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -829,15 +829,16 @@ function unwrapClipboardHtmlEnvelope(tree) {
  * @param {HastNodes} node Fix the tree below this node
  */
 function removeFragmentMarkers(node) {
-  visit(node, (node) => {
-    if (node.type === 'comment' && 
-        (node.value === 'StartFragment' || node.value === 'EndFragment')) {
-      return node;
+  visit(
+    node,
+    (node) =>
+      node.type === 'comment' &&
+      (node.value === 'StartFragment' || node.value === 'EndFragment'),
+    (_node, index, parent) => {
+      parent.children.splice(index, 1);
+      return index;
     }
-  }, (node, index, parent) => {
-    parent.children.splice(index, 1);
-    return index;
-  });
+  );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     {
       "name": "Ben Sheldon",
       "url": "https://github.com/bensheldon"
+    },
+    {
+      "name": "Jace Sleeman",
+      "url": "https://github.com/TheRealPerson98"
     }
   ],
   "license": "BSD-3-Clause",

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -203,4 +203,14 @@ describe('convert', () => {
       );
     });
   });
+
+  it('removes browser-added fragment markers', async () => {
+    let md = await convertDocsHtmlToMarkdown(`
+      <!--StartFragment-->
+      <p>This is a test paragraph</p>
+      <!--EndFragment-->
+    `);
+
+    expect(md).toEqual('This is a test paragraph\n');
+  });
 });


### PR DESCRIPTION
When copying content from Google Docs, browsers add HTML comments `<!--StartFragment-->` and `<!--EndFragment-->` to mark the copied content. These markers are not part of the actual document content and show up in the final markdown output.

This PR:
- Adds a new `removeFragmentMarkers` function that removes these browser-added HTML comments
- Integrates the cleanup into the existing `cleanGoogleHtml` pipeline
- Preserves all other HTML comments that might be meaningful

The change improves the quality of the output markdown by removing unnecessary markup that browsers add during the copy/paste process.

Example of the issue:

```markdown
<!--StartFragment-->
# My Document
Some content here
<!--EndFragment-->
```

Becomes just:

```markdown
# My Document
Some content here
```