### PR TITLE
My combined changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,10 @@
           Downgrade Headers:
           <input type="checkbox" name="downgradeHeaders">
         </label>
+        <label>
+          Detect Document Title:
+          <input type="checkbox" name="detectTitle" checked>
+        </label>
 
         <label>
           Table of Contents:

--- a/index.html
+++ b/index.html
@@ -179,6 +179,11 @@
             <option value="reject">Reject/ignore suggestions</option>
           </select>
         </label>
+
+        <label>
+          Downgrade Headers:
+          <input type="checkbox" name="downgradeHeaders">
+        </label>
       </form>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -184,6 +184,14 @@
           Downgrade Headers:
           <input type="checkbox" name="downgradeHeaders">
         </label>
+
+        <label>
+          Table of Contents:
+          <select name="tableOfContentsStyle">
+            <option value="replace">Replace with [TOC]</option>
+            <option value="keep">Keep as links</option>
+          </select>
+        </label>
       </form>
     </header>
 

--- a/lib-ui/settings.js
+++ b/lib-ui/settings.js
@@ -42,5 +42,10 @@ export const settings = {
   },
 
   _storageKey: 'gdoc2md.options',
-  _data: {},
+  _data: {
+    downgradeHeaders: false,
+    codeBlocks: 'indented',
+    headingIds: 'hidden',
+    suggestions: 'reject'
+  },
 };

--- a/lib-ui/settings.js
+++ b/lib-ui/settings.js
@@ -46,6 +46,7 @@ export const settings = {
     downgradeHeaders: false,
     codeBlocks: 'indented',
     headingIds: 'hidden',
-    suggestions: 'reject'
+    suggestions: 'reject',
+    detectTitle: true,
   },
 };

--- a/lib-ui/settings.js
+++ b/lib-ui/settings.js
@@ -43,10 +43,11 @@ export const settings = {
 
   _storageKey: 'gdoc2md.options',
   _data: {
-    downgradeHeaders: false,
+    downgradeHeaders: true,
     codeBlocks: 'indented',
     headingIds: 'hidden',
     suggestions: 'reject',
     detectTitle: true,
+    tableOfContentsStyle: 'replace',
   },
 };

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -20,6 +20,7 @@ export const defaultOptions = {
   codeBlocks: 'indented',
   headingIds: 'hidden',
   suggestions: 'reject',
+  detectTitle: true,
   tocHandling: 'replace',
 };
 
@@ -40,9 +41,13 @@ function preserveTagAndConvertContents(state, node, _parent) {
 function headingWithIdHandler({ headingIds, downgradeHeaders }) {
   /** @type {Handle} */
   return function headingToMdast(state, node, _parent) {
+    const isDetectedTitle = node.properties?.__detectedTitle || false;
     const originalLevel = parseInt(node.tagName.slice(1), 10);
-    let level = downgradeHeaders ? originalLevel + 1 : originalLevel;
     
+    const level = downgradeHeaders && !isDetectedTitle ?
+      originalLevel + 1 :
+      originalLevel;
+
     // If we exceed h6, convert to bold text paragraph
     let useBold = false;
     if (level > 6) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -36,10 +36,37 @@ function preserveTagAndConvertContents(state, node, _parent) {
  * @param {object} options
  * @returns {Handle}
  */
-function headingWithIdHandler({ headingIds }) {
+function headingWithIdHandler({ headingIds, downgradeHeaders }) {
   /** @type {Handle} */
   return function headingToMdast(state, node, _parent) {
-    const newNode = defaultHandlers[node.tagName](state, node);
+    const originalLevel = parseInt(node.tagName.slice(1), 10);
+    let level = downgradeHeaders ? originalLevel + 1 : originalLevel;
+    
+    // If we exceed h6, convert to bold text paragraph
+    let useBold = false;
+    if (level > 6) {
+      useBold = true;
+      level = 6; // Fallback to h6 structure but will convert to paragraph
+    }
+
+    let newNode;
+    if (useBold) {
+      newNode = {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'strong',
+            children: state.all(node)
+          }
+        ]
+      };
+    } else {
+      newNode = {
+        type: 'heading',
+        depth: level,
+        children: state.all(node)
+      };
+    }
 
     if (node.properties?.id) {
       let idCode = '';

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -63,7 +63,7 @@ function headingWithIdHandler({ headingIds, downgradeHeaders }) {
         children: [
           {
             type: 'strong',
-            children: state.all(node)
+            children: [{ type: 'text', value: getHastTextContent(node) }]
           }
         ]
       };
@@ -71,7 +71,7 @@ function headingWithIdHandler({ headingIds, downgradeHeaders }) {
       newNode = {
         type: 'heading',
         depth: level,
-        children: state.all(node)
+        children: [{ type: 'text', value: getHastTextContent(node) }]
       };
     }
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -20,6 +20,7 @@ export const defaultOptions = {
   codeBlocks: 'indented',
   headingIds: 'hidden',
   suggestions: 'reject',
+  tocHandling: 'replace',
 };
 
 /** @type {Handle} */
@@ -109,6 +110,7 @@ function anchorHandler({ headingIds }) {
       if (href?.startsWith('#')) {
         const target = state.elementById.get(href.slice(1));
         if (target && /^h\d$/.test(target.tagName) && headingIds === 'hidden') {
+          slugger.reset();
           const headingSlug = slugger.slug(getHastTextContent(target));
           node.properties.href = `#${headingSlug}`;
         }
@@ -209,7 +211,11 @@ export async function convertDocsHtmlToMarkdown(html, rawSliceClip, options) {
     data: { options },
   });
 
-  return result.value;
+  let output = result.value;
+  if (options.tableOfContentsStyle === 'replace') {
+    output = output.replace(/\\?\[TOC\\?\]/g, '[TOC]');
+  }
+  return output;
 }
 
 export async function combineGoogleDocFormats(html, rawSliceClip) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -21,7 +21,8 @@ export const defaultOptions = {
   headingIds: 'hidden',
   suggestions: 'reject',
   detectTitle: true,
-  tocHandling: 'replace',
+  downgradeHeaders: true,
+  tableOfContentsStyle: 'replace',
 };
 
 /** @type {Handle} */

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -845,6 +845,39 @@ function removeFragmentMarkers(node) {
   );
 }
 
+function replaceTableOfContents(node) {
+  let inTOC = false;
+  let tocStartIndex = -1;
+  let tocLength = 0;
+  
+  // First pass: Identify TOC section (consecutive heading links)
+  node.children?.forEach((child, index) => {
+    if (child.type === 'element' && child.tagName === 'p' &&
+        child.children?.length === 1 && child.children[0].tagName === 'a' &&
+        child.children[0].properties?.href?.startsWith('#')) {
+      if (!inTOC) {
+        inTOC = true;
+        tocStartIndex = index;
+      }
+      tocLength++;
+    } else if (inTOC) {
+      inTOC = false;
+    }
+  });
+
+  // Second pass: Replace if we found a TOC section
+  if (tocStartIndex !== -1 && tocLength > 0) {
+    node.children.splice(tocStartIndex, tocLength, {
+      type: 'element',
+      tagName: 'p',
+      children: [{
+        type: 'text',
+        value: '[TOC]'
+      }]
+    });
+  }
+}
+
 /**
  * A Unified plugin that adds metadata from a Google Docs "Slice Clip" object
  * into the HTML/HAST tree of a pasted Google Doc.
@@ -885,7 +918,9 @@ export function cleanGoogleHtml() {
     removeLineBreaksBeforeBlocks(tree);
     fixChecklists(tree);
     removeFragmentMarkers(tree);
-
+    if (file.data.options?.tableOfContentsStyle === 'replace') {
+      replaceTableOfContents(tree);
+    }
     return tree;
   };
 }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -498,39 +498,43 @@ function isAllTextCode(parent) {
 export function createCodeBlocks(node) {
   if (!node.children?.length) return;
 
-  // TODO: identify *lines* that are all code (not just block elements) by
-  // splitting on `<br>` nodes, and break up parent blocks that have complete
-  // code lines in them.
-
   const codeBlocks = [];
   let activeCodeBlock = null;
+  
+  // Helper to check if a node is an empty paragraph
+  const isEmptyParagraph = (n) => 
+    n.tagName === 'p' && 
+    (n.children.length === 0 || 
+     (n.children.length === 1 && n.children[0].tagName === 'br'));
+
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];
-    // Don't rewrite already-existing code block markup.
+    
     if (child?.tagName === 'code' || child?.tagName === 'pre') continue;
 
     if (isBlock(child)) {
-      if (isAllTextCode(child)) {
-        if (!activeCodeBlock) {
-          activeCodeBlock = { node, start: i, end: 0 };
+      if (isAllTextCode(child) || (activeCodeBlock && isEmptyParagraph(child))) {
+        if (activeCodeBlock) {
+          // Extend existing code block if it's consecutive or separated by empty paragraph
+          activeCodeBlock.end = i + 1;
+        } else {
+          // Start new code block
+          activeCodeBlock = { node, start: i, end: i + 1 };
           codeBlocks.push(activeCodeBlock);
         }
       } else {
-        if (activeCodeBlock) {
-          activeCodeBlock.end = i;
-          activeCodeBlock = null;
-        }
+        activeCodeBlock = null;
       }
     } else {
       createCodeBlocks(child);
     }
   }
+
   if (activeCodeBlock) {
     activeCodeBlock.end = node.children.length;
   }
 
-  // Go in reverse order so we can use the indexes as is, without worrying about
-  // how replacing each block changes the indexes of the next one.
+  // Existing code to wrap blocks...
   for (const block of codeBlocks.reverse()) {
     wrapInCodeBlock(block);
   }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -907,6 +907,10 @@ export function updateHtmlWithSliceClip() {
  */
 export function cleanGoogleHtml() {
   return (tree, file) => {
+    if (file.data.options?.detectTitle) {
+      convertTitleToHeading(tree, file.data.options);
+    }
+
     formatSuggestions(tree, file.data.options);
     unInlineStyles(tree);
     createCodeBlocks(tree);
@@ -923,4 +927,40 @@ export function cleanGoogleHtml() {
     }
     return tree;
   };
+}
+
+/** 
+ * Convert first large text block to H1 if it looks like a title
+ */
+function convertTitleToHeading(tree, options) {
+  let foundTitle = false;
+  
+  visit(tree, (node, index, parent) => {
+    if (foundTitle || node.tagName !== 'p') return;
+    
+    const firstChild = node.children?.[0];
+    if (!firstChild || firstChild.tagName !== 'span') return;
+    
+    const style = resolveNodeStyle(firstChild);
+    const isTitleCandidate = (
+      parseInt(style['font-size']) >= 24 || // 24pt or larger
+      style['font-weight'] === 'bold' ||
+      style['font-weight'] === '700'
+    );
+
+    if (isTitleCandidate) {
+      // Replace paragraph with H1 and mark as detected title
+      parent.children.splice(index, 1, {
+        type: 'element',
+        tagName: 'h1',
+        properties: {
+          __detectedTitle: true
+        },
+        children: node.children
+      });
+      
+      foundTitle = true;
+      return EXIT;
+    }
+  });
 }

--- a/lib/hast-tools.js
+++ b/lib/hast-tools.js
@@ -63,6 +63,7 @@ export function wrapInCodeBlock(range, language = null) {
         tagName: 'code',
         properties: {
           className: languageClasses,
+          dataLanguage: language || '',
         },
         children: contents,
       },

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "main": "./lib-ui/index.js",
   "type": "module",
   "scripts": {
-    "build": "mkdir -p dist && webpack",
+    "build": "webpack",
     "clean": "rm -rf dist/*; rm -rf logs/*; rm -rf temp/*",
-    "start": "mkdir -p dist && webpack serve",
+    "start": "webpack serve",
     "test": "npm run test-unit && npm run test-e2e",
     "test-unit": "wdio run ./wdio.conf.unit.js --coverage",
     "test-e2e": "wdio run ./wdio.conf.e2e.js",


### PR DESCRIPTION
I have a number of new options and minor tweaks and fixes that I can submit in several PRs if preferred, but I would have to do some additional cleanup and a couple branches depend on each other and would have to go in order. I thought I would start by submitting this together to avoid procrastination on my part.

**Fixes/ Enhancements**:

Continuous code blocks: Combine fenced code blocks that aren't separated by a new line without formatting changes in the html

Don't over-format headers: Header blocks do not need additional formatting like bold and italics. Let's strip the plain text for this conversion.

**New Options**:

Downgrade headers: It's usually bad form to have more than one H1 heading. Add an option to downgrade headers by 1. If we reach H6, convert to a paragraph with bolded text.

Detect Title: Titles aren't a header in google docs. Let's add an option to try to detect titles. Pairs well with downgrade headers.

Table of Contents: Let's add an option to replace the table of contents with the `[TOC]` macro supported by many extended markdown renderers or to leave as a list of converted links.

**Example Options Fields with Sample Input and Output**:

![image](https://github.com/user-attachments/assets/e21d0260-13dd-49c6-b86c-e55bccc85fda)


