### PR TITLE
Fix images being interpreted as code blocks and inline code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This project is open source, and gets better with the hard work and collaboratio
 | [💻](# "Code") | [Tamás Halasi](https://github.com/trustedtomato) |
 | [💻](# "Code") [⚠️](# "Tests") | [Jack Kingsman](https://github.com/jkingsman) |
 | [💻](# "Code") | [Peter Law](https://github.com/PeterJCLaw) |
+| [💻](# "Code") | [@MaderHatt3r](https://github.com/MaderHatt3r) |
 | [📖](# "Documentation") [🚇](# "Infrastructure") | [Marcin Rataj](https://github.com/lidel) |
 | [💻](# "Code") | [Ben Sheldon](https://github.com/bensheldon) |
 | [💻](# "Code") | [Jace Sleeman](https://github.com/TheRealPerson98) |

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -105,14 +105,25 @@ const spaceAtStartPattern = /^(\s+)/;
 const spaceAtEndPattern = /(\s+)$/;
 
 /**
- * Helper to check if a node contains any images, recursively searching through children
+ * Helper to check if a node contains any replaced elements that should not be
+ * wrapped in code elements. Replaced elements are those that are replaced by
+ * external content or represent non-text media.
  * @param {HastNodes} node The node to check
- * @returns {boolean} True if the node or any of its descendants is an image
+ * @returns {boolean} True if the node or any of its descendants is a replaced element
  */
-const containsImage = (node) => {
-  if (node.tagName === 'img') return true;
+const containsReplacedElement = (node) => {
+  // Common replaced elements in HTML
+  if (['img', 'video', 'iframe', 'embed', 'fencedframe', 'audio', 'canvas', 'object'].includes(node.tagName)) {
+    return true;
+  }
+  
+  // Special case for <input type="image">
+  if (node.tagName === 'input' && node.properties?.type === 'image') {
+    return true;
+  }
+  
   if (!node.children?.length) return false;
-  return node.children.some(child => containsImage(child));
+  return node.children.some(child => containsReplacedElement(child));
 };
 
 /**
@@ -207,8 +218,8 @@ function convertInlineStylesToElements(node) {
 
       // Google docs doesn't really have anything that represents "code", so
       // infer it from the use of monospace fonts.
-      // Don't wrap in code if there's an image present
-      if (/,\s*monospace/.test(style['font-family']) && !containsImage(node)) {
+      // Don't wrap in code if there's a replaced element present
+      if (/,\s*monospace/.test(style['font-family']) && !containsReplacedElement(node)) {
         wrapChildren(node, hast('code'));
       }
 
@@ -483,8 +494,8 @@ function isAllTextCode(parent) {
 
   let hasText = false;
   for (const child of parent.children) {
-    // Don't create code blocks if there are images present
-    if (child.tagName === 'img') {
+    // Don't create code blocks if there are replaced elements present
+    if (containsReplacedElement(child)) {
       return false;
     }
     
@@ -528,8 +539,8 @@ export function createCodeBlocks(node) {
     if (child?.tagName === 'code' || child?.tagName === 'pre') continue;
 
     if (isBlock(child)) {
-      // Check both for code and absence of images
-      if (isAllTextCode(child) && !containsImage(child)) {
+      // Check both for code and absence of replaced elements
+      if (isAllTextCode(child) && !containsReplacedElement(child)) {
         if (!activeCodeBlock) {
           activeCodeBlock = { node, start: i, end: i + 1 };
           codeBlocks.push(activeCodeBlock);
@@ -541,7 +552,6 @@ export function createCodeBlocks(node) {
           activeCodeBlock.end = i;
           activeCodeBlock = null;
         }
-
       }
     } else {
       createCodeBlocks(child);

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -164,6 +164,13 @@ export function unInlineStyles(node) {
  * @param {HastNodes} node Fix the tree below this node
  */
 function convertInlineStylesToElements(node) {
+  // Helper to check if a node contains any images
+  const containsImage = (node) => {
+    if (node.tagName === 'img') return true;
+    if (!node.children?.length) return false;
+    return node.children.some(child => containsImage(child));
+  };
+
   visitParents(
     node,
     (n) => isStyled(n) && !isBlock(n),
@@ -196,7 +203,8 @@ function convertInlineStylesToElements(node) {
 
       // Google docs doesn't really have anything that represents "code", so
       // infer it from the use of monospace fonts.
-      if (/,\s*monospace/.test(style['font-family'])) {
+      // Don't wrap in code if there's an image present
+      if (/,\s*monospace/.test(style['font-family']) && !containsImage(node)) {
         wrapChildren(node, hast('code'));
       }
 
@@ -471,6 +479,11 @@ function isAllTextCode(parent) {
 
   let hasText = false;
   for (const child of parent.children) {
+    // Don't create code blocks if there are images present
+    if (child.tagName === 'img') {
+      return false;
+    }
+    
     if (child.tagName === 'code') {
       hasText = true;
       continue;
@@ -504,27 +517,40 @@ export function createCodeBlocks(node) {
 
   const codeBlocks = [];
   let activeCodeBlock = null;
+  
+  // Helper to check if a node contains any images
+  const containsImage = (node) => {
+    if (node.tagName === 'img') return true;
+    if (!node.children?.length) return false;
+    return node.children.some(child => containsImage(child));
+  };
+
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];
     // Don't rewrite already-existing code block markup.
     if (child?.tagName === 'code' || child?.tagName === 'pre') continue;
 
     if (isBlock(child)) {
-      if (isAllTextCode(child)) {
+      // Check both for code and absence of images
+      if (isAllTextCode(child) && !containsImage(child)) {
         if (!activeCodeBlock) {
-          activeCodeBlock = { node, start: i, end: 0 };
+          activeCodeBlock = { node, start: i, end: i + 1 };
           codeBlocks.push(activeCodeBlock);
+        } else {
+          activeCodeBlock.end = i + 1;
         }
       } else {
         if (activeCodeBlock) {
           activeCodeBlock.end = i;
           activeCodeBlock = null;
         }
+
       }
     } else {
       createCodeBlocks(child);
     }
   }
+
   if (activeCodeBlock) {
     activeCodeBlock.end = node.children.length;
   }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -114,17 +114,28 @@ const spaceAtEndPattern = /(\s+)$/;
  */
 const containsReplacedElement = (node) => {
   // Common replaced elements in HTML
-  if (['img', 'video', 'iframe', 'embed', 'fencedframe', 'audio', 'canvas', 'object'].includes(node.tagName)) {
+  if (
+    [
+      'img',
+      'video',
+      'iframe',
+      'embed',
+      'fencedframe',
+      'audio',
+      'canvas',
+      'object',
+    ].includes(node.tagName)
+  ) {
     return true;
   }
-  
+
   // Special case for <input type="image">
   if (node.tagName === 'input' && node.properties?.type === 'image') {
     return true;
   }
-  
+
   if (!node.children?.length) return false;
-  return node.children.some(child => containsReplacedElement(child));
+  return node.children.some((child) => containsReplacedElement(child));
 };
 
 /**
@@ -220,7 +231,10 @@ function convertInlineStylesToElements(node) {
       // Google docs doesn't really have anything that represents "code", so
       // infer it from the use of monospace fonts.
       // Don't wrap in code if there's a replaced element present
-      if (/,\s*monospace/.test(style['font-family']) && !containsReplacedElement(node)) {
+      if (
+        /,\s*monospace/.test(style['font-family']) &&
+        !containsReplacedElement(node)
+      ) {
         wrapChildren(node, hast('code'));
       }
 
@@ -499,7 +513,7 @@ function isAllTextCode(parent) {
     if (containsReplacedElement(child)) {
       return false;
     }
-    
+
     if (child.tagName === 'code') {
       hasText = true;
       continue;
@@ -544,7 +558,7 @@ export function createCodeBlocks(node) {
       if (isAllTextCode(child) && !containsReplacedElement(child)) {
         if (!activeCodeBlock) {
           // Start a new code block when a new one is found
-          activeCodeBlock = { node, start: i};
+          activeCodeBlock = { node, start: i };
           codeBlocks.push(activeCodeBlock);
         }
       } else {

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -542,13 +542,14 @@ export function createCodeBlocks(node) {
       // Check both for code and absence of replaced elements
       if (isAllTextCode(child) && !containsReplacedElement(child)) {
         if (!activeCodeBlock) {
-          activeCodeBlock = { node, start: i, end: i + 1 };
+          // Start a new code block when a new one is found
+          activeCodeBlock = { node, start: i};
           codeBlocks.push(activeCodeBlock);
-        } else {
-          activeCodeBlock.end = i + 1;
         }
       } else {
         if (activeCodeBlock) {
+          // End the previous code block when the current line
+          // is no longer a code block
           activeCodeBlock.end = i;
           activeCodeBlock = null;
         }
@@ -558,6 +559,7 @@ export function createCodeBlocks(node) {
     }
   }
 
+  // End the code block if all lines were code
   if (activeCodeBlock) {
     activeCodeBlock.end = node.children.length;
   }

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -87,6 +87,19 @@ const voidElements = new Set([
   'wbr',
 ]);
 
+// "Replaced" elements are elements that display content from some subresource
+// rather than the text of the DOM inside them.
+const replacedElements = new Set([
+  'img',
+  'video',
+  'iframe',
+  'embed',
+  'fencedframe',
+  'audio',
+  'canvas',
+  'object',
+]);
+
 // These elements convert to Markdown nodes that can't start or end with spaces.
 // For example, you can't start emphasis with a space: `This * is emphasized*`.
 const spaceSensitiveElements = new Set(['em', 'strong', 'ins', 'del']);
@@ -105,27 +118,16 @@ const spaceAtStartPattern = /^(\s+)/;
 const spaceAtEndPattern = /(\s+)$/;
 
 /**
- * Helper to check if a node contains any replaced elements that should not be
- * wrapped in code elements. Replaced elements are those that are replaced by
- * external content or represent non-text media.
+ * Check if a node contains any replaced elements and shouldn't be wrapped in
+ * some Markdown markup that prevents them from displaying (e.g. a code block).
+ * Replaced elements are those that are replaced by external content or
+ * represent non-text media.
  * @param {HastNodes} node The node to check
  * @returns {boolean} True if the node or any of its descendants
  *                    is a replaced element
  */
-const containsReplacedElement = (node) => {
-  // Common replaced elements in HTML
-  if (
-    [
-      'img',
-      'video',
-      'iframe',
-      'embed',
-      'fencedframe',
-      'audio',
-      'canvas',
-      'object',
-    ].includes(node.tagName)
-  ) {
+function containsReplacedElement(node) {
+  if (replacedElements.has(node.tagName)) {
     return true;
   }
 
@@ -134,9 +136,8 @@ const containsReplacedElement = (node) => {
     return true;
   }
 
-  if (!node.children?.length) return false;
-  return node.children.some((child) => containsReplacedElement(child));
-};
+  return node.children?.some(containsReplacedElement) ?? false;
+}
 
 /**
  * Fix the incorrect formatting of nested lists in Google Docs's HTML. Lists
@@ -558,7 +559,7 @@ export function createCodeBlocks(node) {
       if (isAllTextCode(child) && !containsReplacedElement(child)) {
         if (!activeCodeBlock) {
           // Start a new code block when a new one is found
-          activeCodeBlock = { node, start: i };
+          activeCodeBlock = { node, start: i, end: i + 1 };
           codeBlocks.push(activeCodeBlock);
         }
       } else {

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -109,7 +109,8 @@ const spaceAtEndPattern = /(\s+)$/;
  * wrapped in code elements. Replaced elements are those that are replaced by
  * external content or represent non-text media.
  * @param {HastNodes} node The node to check
- * @returns {boolean} True if the node or any of its descendants is a replaced element
+ * @returns {boolean} True if the node or any of its descendants
+ *                    is a replaced element
  */
 const containsReplacedElement = (node) => {
   // Common replaced elements in HTML

--- a/lib/fix-google-html.js
+++ b/lib/fix-google-html.js
@@ -105,6 +105,17 @@ const spaceAtStartPattern = /^(\s+)/;
 const spaceAtEndPattern = /(\s+)$/;
 
 /**
+ * Helper to check if a node contains any images, recursively searching through children
+ * @param {HastNodes} node The node to check
+ * @returns {boolean} True if the node or any of its descendants is an image
+ */
+const containsImage = (node) => {
+  if (node.tagName === 'img') return true;
+  if (!node.children?.length) return false;
+  return node.children.some(child => containsImage(child));
+};
+
+/**
  * Fix the incorrect formatting of nested lists in Google Docs's HTML. Lists
  * can only have `div` and `li` children, but Google Docs has other lists as
  * direct descendents. This moves those free-floating lists into the previous
@@ -164,13 +175,6 @@ export function unInlineStyles(node) {
  * @param {HastNodes} node Fix the tree below this node
  */
 function convertInlineStylesToElements(node) {
-  // Helper to check if a node contains any images
-  const containsImage = (node) => {
-    if (node.tagName === 'img') return true;
-    if (!node.children?.length) return false;
-    return node.children.some(child => containsImage(child));
-  };
-
   visitParents(
     node,
     (n) => isStyled(n) && !isBlock(n),
@@ -517,13 +521,6 @@ export function createCodeBlocks(node) {
 
   const codeBlocks = [];
   let activeCodeBlock = null;
-  
-  // Helper to check if a node contains any images
-  const containsImage = (node) => {
-    if (node.tagName === 'img') return true;
-    if (!node.children?.length) return false;
-    return node.children.some(child => containsImage(child));
-  };
 
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
       "url": "https://github.com/PeterJCLaw"
     },
     {
+      "name": "MaderHatt3r",
+      "url": "https://github.com/MaderHatt3r"
+    },
+    {
       "name": "Marcin Rataj",
       "url": "https://github.com/lidel"
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "test": "npm run test-unit && npm run test-e2e",
     "test-unit": "wdio run ./wdio.conf.unit.js --coverage",
     "test-e2e": "wdio run ./wdio.conf.e2e.js",
-    "download-fixtures": "node scripts/download-fixtures.js"
+    "download-fixtures": "node scripts/download-fixtures.js",
+    "lint": "eslint lib/",
+    "lint:fix": "npm run lint -- --fix"
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "test-unit": "wdio run ./wdio.conf.unit.js --coverage",
     "test-e2e": "wdio run ./wdio.conf.e2e.js",
     "download-fixtures": "node scripts/download-fixtures.js",
-    "lint": "eslint lib/",
-    "lint:fix": "npm run lint -- --fix"
+    "lint": "eslint .; prettier --check .",
+    "lint:fix": "eslint --fix .; prettier --write ."
   },
   "devDependencies": {
     "@eslint/js": "^9.8.0",

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -22,6 +22,7 @@ const FIXTURES = {
   'inline-formatting': '1-0E8y62m1tI6MWYYbGcbBALylL9hT9Toq9SssCeT-Ew',
   'lists': '1bZI3NwaasFZGexGQG9YC07UAovpY9b_mfdI2_KgT8-0',
   'list-item-level-styling': '10W_0kk4mBViHMIahKcg4WwBu-HLCyw12BG7NC2lyuA8',
+  'non-text-between-code': '1m83z9i4tSnKw3vWsW3x7RNKMmWEyY_SqNERH0G4k2v0',
   'tables': '1sdDeTF4uEwAlp6VDx_Jk_yJYS0wtnOWj0J63aSU3zsQ',
   'linebreaks-at-the-end-of-links':
     '1YES2UjSQV16TOWhVT0fXoXvYTwrtdcKcO8kxr4-9yPs',

--- a/test/fixtures/non-text-between-code.copy.gdocsliceclip.json
+++ b/test/fixtures/non-text-between-code.copy.gdocsliceclip.json
@@ -1,0 +1,2072 @@
+{
+  "cses": false,
+  "data": {
+    "autotext_content": {
+    },
+    "resolved": {
+      "dsl_drawingrevisionaccesstokenmap": {
+      },
+      "dsl_entitymap": {
+        "kix.c706pz8n9van": {
+          "ee_eo": {
+            "eo_ad": null,
+            "eo_at": null,
+            "eo_bo": {
+              "ln_c2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ln_s": 0,
+              "ln_w": 0
+            },
+            "eo_hb": false,
+            "eo_lco": {
+              "lc_cs": "",
+              "lc_ct": 0,
+              "lc_oi": "",
+              "lc_sci": "",
+              "lc_srk": ""
+            },
+            "eo_mb": 9,
+            "eo_ml": 9,
+            "eo_mr": 9,
+            "eo_mt": 9,
+            "eo_rtd": "",
+            "eo_rtdf": {
+              "rdf_ft": 0
+            },
+            "eo_type": 0,
+            "i_bri": 0,
+            "i_cid": "s-blob-v1-IMAGE-cKif3g_cbeg",
+            "i_clst": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "i_cont": 0,
+            "i_crop": {
+              "crop_hr": 1,
+              "crop_oxr": 0,
+              "crop_oyr": 0,
+              "crop_rot": 0,
+              "crop_wr": 1
+            },
+            "i_ht": 355.5,
+            "i_iw": false,
+            "i_iwc": {
+              "iwc_w": false
+            },
+            "i_msct": 0,
+            "i_opa": 1,
+            "i_rot": 0,
+            "i_src": "",
+            "i_wth": 419.25
+          }
+        }
+      },
+      "dsl_entitypositionmap": {
+        "inline": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          [
+            "kix.c706pz8n9van"
+          ]
+        ]
+      },
+      "dsl_entitytypemap": {
+        "kix.c706pz8n9van": "inline"
+      },
+      "dsl_metastyleslices": [
+        {
+          "stsl_styles": [
+            {
+              "aiss_sm": null
+            }
+          ],
+          "stsl_type": "ai_suggestion"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ac_ct": null,
+              "ac_id": "",
+              "ac_ot": null,
+              "ac_sm": {
+                "asm_l": "",
+                "asm_rl": 0,
+                "asm_s": 0
+              },
+              "ac_type": null
+            }
+          ],
+          "stsl_type": "autocorrect"
+        },
+        {
+          "stsl_styles": [
+            {
+              "colc_icc": false
+            }
+          ],
+          "stsl_type": "collapsed_content"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cd_bgc": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "cd_u": false
+            }
+          ],
+          "stsl_type": "composing_decoration"
+        },
+        {
+          "stsl_styles": [
+            {
+              "cr_c": false
+            }
+          ],
+          "stsl_type": "composing_region"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iwos_i": false
+            }
+          ],
+          "stsl_type": "ignore_word"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ocn_sttc": 0,
+              "ocn_tdsm": null,
+              "ocn_tfsm": null
+            }
+          ],
+          "stsl_type": "on_canvas_nudges"
+        },
+        {
+          "stsl_styles": [
+            {
+              "revdiff_a": "",
+              "revdiff_aid": "",
+              "revdiff_dt": 0
+            }
+          ],
+          "stsl_type": "revision_diff"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sc_id": "",
+              "sc_ow": null,
+              "sc_sl": null,
+              "sc_sm": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "sc_sugg": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vcs_c": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              },
+              "vcs_id": ""
+            }
+          ],
+          "stsl_type": "voice_corrections"
+        },
+        {
+          "stsl_styles": [
+            {
+              "vdss_id": "",
+              "vdss_p": null
+            }
+          ],
+          "stsl_type": "voice_dotted_span"
+        }
+      ],
+      "dsl_nestedmodelmap": {
+      },
+      "dsl_relateddocslices": {
+      },
+      "dsl_spacers": "This is a test of non-text content placed in the middle of or between code blocks.\n\nThis is a code block with an image inside.\n\n*\n\nAnd some more code block text after the image.\n\nAnd now some more normal text.\n",
+      "dsl_styleslices": [
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "autogen"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "cell"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "code_snippet"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "collapsed_heading"
+        },
+        {
+          "stsl_leading": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_leadingType": "column_sector",
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "css_cols": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            },
+            "css_epfi": null,
+            "css_ephi": null,
+            "css_fi": null,
+            "css_fpfi": null,
+            "css_fphi": null,
+            "css_fpo": null,
+            "css_hi": null,
+            "css_lb": false,
+            "css_ln": null,
+            "css_ltr": true,
+            "css_mb": null,
+            "css_mf": null,
+            "css_mh": null,
+            "css_ml": null,
+            "css_mr": null,
+            "css_mt": null,
+            "css_pnsi": null,
+            "css_st": "continuous",
+            "css_ufphf": null
+          },
+          "stsl_trailingType": "column_sector",
+          "stsl_type": "column_sector"
+        },
+        {
+          "stsl_leading": {
+            "ds_b": {
+              "bg_c2": {
+                "clr_type": 0,
+                "hclr_color": "#ffffff"
+              }
+            },
+            "ds_ci": null,
+            "ds_df": {
+              "df_dm": 1
+            },
+            "ds_epfi": null,
+            "ds_ephi": null,
+            "ds_fi": null,
+            "ds_fpfi": null,
+            "ds_fphi": null,
+            "ds_fpo": false,
+            "ds_hi": null,
+            "ds_lhs": 1,
+            "ds_ln": {
+              "ln_lne": false,
+              "ln_lnm": 0
+            },
+            "ds_mb": 36,
+            "ds_mf": 36,
+            "ds_mh": 36,
+            "ds_ml": 36,
+            "ds_mr": 36,
+            "ds_mt": 36,
+            "ds_ph": 792,
+            "ds_pnsi": 1,
+            "ds_pw": 612,
+            "ds_rtd": "",
+            "ds_uephf": false,
+            "ds_ufphf": false,
+            "ds_ulhfl": false
+          },
+          "stsl_leadingType": "document",
+          "stsl_styles": [
+          ],
+          "stsl_type": "document"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "equation_function"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "esgs_s": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                ]
+              }
+            }
+          },
+          "stsl_trailingType": "esignature_signers",
+          "stsl_type": "esignature_signers"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "field"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "footnote"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "headings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "horizontal_rule"
+        },
+        {
+          "stsl_styles": [
+            {
+              "isc_osh": null,
+              "isc_smer": true
+            }
+          ],
+          "stsl_type": "ignore_spellcheck"
+        },
+        {
+          "stsl_styles": [
+            {
+              "iws_iwids": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "import_warnings"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_trailing": {
+            "lgs_l": "en"
+          },
+          "stsl_trailingType": "language",
+          "stsl_type": "language"
+        },
+        {
+          "stsl_styles": [
+            {
+              "lnks_link": null
+            }
+          ],
+          "stsl_type": "link"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ls_c": null,
+              "ls_id": null,
+              "ls_nest": 0,
+              "ls_ts": {
+                "ts_bd": false,
+                "ts_bd_i": false,
+                "ts_bgc2": {
+                  "clr_type": 0,
+                  "hclr_color": null
+                },
+                "ts_bgc2_i": false,
+                "ts_ff": "Arial",
+                "ts_ff_i": false,
+                "ts_fgc2": {
+                  "clr_type": 0,
+                  "hclr_color": "#000000"
+                },
+                "ts_fgc2_i": false,
+                "ts_fs": 11,
+                "ts_fs_i": false,
+                "ts_it": false,
+                "ts_it_i": false,
+                "ts_sc": false,
+                "ts_sc_i": false,
+                "ts_st": false,
+                "ts_st_i": false,
+                "ts_tw": 400,
+                "ts_un": false,
+                "ts_un_i": false,
+                "ts_va": "nor",
+                "ts_va_i": false
+              }
+            }
+          ],
+          "stsl_type": "list"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ms_id": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "markup"
+        },
+        {
+          "stsl_styles": [
+            {
+              "nrs_ei": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "named_range"
+        },
+        {
+          "stsl_styles": [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ps_al": 0,
+              "ps_al_i": false,
+              "ps_awao": false,
+              "ps_awao_i": false,
+              "ps_bb": null,
+              "ps_bb_i": false,
+              "ps_bbtw": null,
+              "ps_bbtw_i": false,
+              "ps_bl": null,
+              "ps_bl_i": false,
+              "ps_br": null,
+              "ps_br_i": false,
+              "ps_bt": null,
+              "ps_bt_i": false,
+              "ps_hd": 0,
+              "ps_hdid": "",
+              "ps_ifl": 0,
+              "ps_ifl_i": false,
+              "ps_il": 0,
+              "ps_il_i": false,
+              "ps_ir": 0,
+              "ps_ir_i": false,
+              "ps_klt": false,
+              "ps_klt_i": false,
+              "ps_kwn": false,
+              "ps_kwn_i": false,
+              "ps_ls": 1.15,
+              "ps_ls_i": false,
+              "ps_lslm": 0,
+              "ps_lslm_i": false,
+              "ps_ltr": true,
+              "ps_pbb": false,
+              "ps_pbb_i": false,
+              "ps_rd": "",
+              "ps_sa": 0,
+              "ps_sa_i": false,
+              "ps_sb": 0,
+              "ps_sb_i": false,
+              "ps_sd": null,
+              "ps_sd_i": false,
+              "ps_shd": false,
+              "ps_sm": 0,
+              "ps_sm_i": false,
+              "ps_ts": {
+                "cv": {
+                  "op": "set",
+                  "opValue": [
+                  ]
+                }
+              }
+            }
+          ],
+          "stsl_type": "paragraph"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "row"
+        },
+        {
+          "stsl_styles": [
+            {
+              "sfs_sst": false
+            }
+          ],
+          "stsl_type": "suppress_feature"
+        },
+        {
+          "stsl_styles": [
+          ],
+          "stsl_type": "tbl"
+        },
+        {
+          "stsl_styles": [
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "PT Sans",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "PT Mono",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            },
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              "ts_bd": false,
+              "ts_bd_i": false,
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_bgc2_i": false,
+              "ts_ff": "PT Sans",
+              "ts_ff_i": false,
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_fgc2_i": false,
+              "ts_fs": 11,
+              "ts_fs_i": false,
+              "ts_it": false,
+              "ts_it_i": false,
+              "ts_sc": false,
+              "ts_sc_i": false,
+              "ts_st": false,
+              "ts_st_i": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_un_i": false,
+              "ts_va": "nor",
+              "ts_va_i": false
+            }
+          ],
+          "stsl_type": "text"
+        }
+      ],
+      "dsl_suggesteddeletions": {
+        "sgsl_sugg": [
+        ]
+      },
+      "dsl_suggestedinsertions": {
+        "sgsl_sugg": [
+        ]
+      }
+    }
+  },
+  "dct": "kix",
+  "dih": 3392617533,
+  "ds": false,
+  "edi": "<random>",
+  "edrk": "<random>",
+  "sm": "other"
+}

--- a/test/fixtures/non-text-between-code.copy.html
+++ b/test/fixtures/non-text-between-code.copy.html
@@ -1,0 +1,35 @@
+<meta charset="utf-8">
+<b style="font-weight:normal;" id="docs-internal-guid-dddddddd-dddd-dddd-dddd-123456789abc">
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size:11pt;font-family:'PT Sans',sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
+			This is a test of non-text content placed in the middle of or between code blocks.
+		</span>
+	</p>
+	<br />
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size:11pt;font-family:'PT Mono',monospace;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
+			This is a code block with an image inside.
+		</span>
+	</p>
+	<br />
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size:11pt;font-family:'PT Mono',monospace;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
+			<span style="border:none;display:inline-block;overflow:hidden;width:559px;height:474px;">
+				<img src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXfOUdieC9bo7QjPnX1ROFNOXtJPZ9xPJAQ7qhlBzsNmw8XuSlVJi-vFeFNs9mXCoDB10pBicZwOpqO5bsEYsIPc_lcCDIsWfGVw18r6kSA9nygfvJsTB44V8E5OU80p5Ts?key=l0-uU5y2NRVMw07JkC0hlbQj" width="559" height="474" style="margin-left:0px;margin-top:0px;" />
+			</span>
+		</span>
+	</p>
+	<br />
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size:11pt;font-family:'PT Mono',monospace;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
+			And some more code block text after the image.
+		</span>
+	</p>
+	<br />
+	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
+		<span style="font-size:11pt;font-family:'PT Sans',sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
+			And now some more normal text.
+		</span>
+	</p>
+</b>
+<br class="Apple-interchange-newline">

--- a/test/fixtures/non-text-between-code.expected.md
+++ b/test/fixtures/non-text-between-code.expected.md
@@ -1,0 +1,9 @@
+This is a test of non-text content placed in the middle of or between code blocks.
+
+    This is a code block with an image inside.
+
+![](https://lh7-rt.googleusercontent.com/docsz/AD_4nXfOUdieC9bo7QjPnX1ROFNOXtJPZ9xPJAQ7qhlBzsNmw8XuSlVJi-vFeFNs9mXCoDB10pBicZwOpqO5bsEYsIPc_lcCDIsWfGVw18r6kSA9nygfvJsTB44V8E5OU80p5Ts?key=l0-uU5y2NRVMw07JkC0hlbQj)
+
+    And some more code block text after the image.
+
+And now some more normal text.

--- a/test/fixtures/non-text-between-code.export.html
+++ b/test/fixtures/non-text-between-code.export.html
@@ -1,0 +1,182 @@
+<html>
+	<head>
+		<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+		<style type="text/css">
+			@import url(https://themes.googleusercontent.com/fonts/css?kit=HpM2VfY4_JujZv-QUxcSfQwHKtuvH1m3U7Mmv5BaptRyCS_r8o6kL6871AzL5VAI);
+ol{
+	margin:0;
+	padding:0
+}
+table td,table th{
+	padding:0
+}
+.c1{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"PT Mono";
+	font-style:normal
+}
+.c0{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"PT Sans";
+	font-style:normal
+}
+.c2{
+	padding-top:0pt;
+	padding-bottom:0pt;
+	line-height:1.15;
+	text-align:left
+}
+.c4{
+	background-color:#ffffff;
+	max-width:540pt;
+	padding:36pt 36pt 36pt 36pt
+}
+.c3{
+	height:11pt
+}
+.title{
+	padding-top:24pt;
+	color:#000000;
+	font-weight:700;
+	font-size:36pt;
+	padding-bottom:6pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	text-align:left
+}
+.subtitle{
+	padding-top:18pt;
+	color:#666666;
+	font-size:24pt;
+	padding-bottom:4pt;
+	font-family:"Georgia";
+	line-height:1.15;
+	font-style:italic;
+	text-align:left
+}
+li{
+	color:#000000;
+	font-size:11pt;
+	font-family:"PT Sans"
+}
+p{
+	margin:0;
+	color:#000000;
+	font-size:11pt;
+	font-family:"PT Sans"
+}
+h1{
+	padding-top:24pt;
+	color:#000000;
+	font-weight:700;
+	font-size:18pt;
+	padding-bottom:6pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	text-align:left
+}
+h2{
+	padding-top:18pt;
+	color:#000000;
+	font-weight:700;
+	font-size:14pt;
+	padding-bottom:4pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	text-align:left
+}
+h3{
+	padding-top:14pt;
+	color:#666666;
+	font-weight:700;
+	font-size:12pt;
+	padding-bottom:4pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	text-align:left
+}
+h4{
+	padding-top:12pt;
+	color:#666666;
+	font-size:11pt;
+	padding-bottom:2pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	font-style:italic;
+	text-align:left
+}
+h5{
+	padding-top:11pt;
+	color:#666666;
+	font-weight:700;
+	font-size:10pt;
+	padding-bottom:2pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	text-align:left
+}
+h6{
+	padding-top:10pt;
+	color:#666666;
+	font-size:10pt;
+	padding-bottom:2pt;
+	font-family:"PT Sans";
+	line-height:1.15;
+	font-style:italic;
+	text-align:left
+}
+
+		</style>
+	</head>
+	<body class="c4 doc-content">
+		<p class="c2">
+			<span>
+				This is a test of non-text content placed in the middle of or between code blocks.
+			</span>
+		</p>
+		<p class="c2 c3">
+			<span class="c0">
+			</span>
+		</p>
+		<p class="c2">
+			<span class="c1">
+				This is a code block with an image inside.
+			</span>
+		</p>
+		<p class="c2 c3">
+			<span class="c1">
+			</span>
+		</p>
+		<p class="c2">
+			<span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 559.00px; height: 474.00px;">
+				<img alt="" src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXey_MeSyDrcK6YXzFgmSWwLfStiaCy9h-mtF5gSTqrXA-pxxfvF2hi12wEMgDyI-JV0g-nKcWy62Mgo3bhm64EwAwaQutCUTAvLJPuY3ugC-pOrwAuozf3447S-JOUxkBg?key=l0-uU5y2NRVMw07JkC0hlbQj" style="width: 559.00px; height: 474.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title="">
+			</span>
+		</p>
+		<p class="c2 c3">
+			<span class="c1">
+			</span>
+		</p>
+		<p class="c2">
+			<span class="c1">
+				And some more code block text after the image.
+			</span>
+		</p>
+		<p class="c2 c3">
+			<span class="c1">
+			</span>
+		</p>
+		<p class="c2">
+			<span>
+				And now some more normal text.
+			</span>
+		</p>
+	</body>
+</html>

--- a/test/unit/convert.test.js
+++ b/test/unit/convert.test.js
@@ -99,6 +99,9 @@ describe('convert', () => {
     options: { headingIds: 'html' },
   });
 
+  createFixtureTest('non-text-between-code', { type: 'copy' });
+  createFixtureTest('non-text-between-code', { type: 'export', skip: true });
+
   // At current, it doesn't seem like this situation can happen in a Google Doc,
   // but it's worth supporting just in case things change or users want to
   // convert more arbitrary HTML.


### PR DESCRIPTION
This fixes images failing to be converted when they are in the middle of code blocks or are converted to an inline code block due to formatting.