### PR TITLE
Clean up asset URLs in fixtures

### DIFF
--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -37,8 +37,8 @@ const DOCUMENT_SLICE_CLIP_TYPE =
 // we anonymously copy a fixture we get a different URL. Replace the key with
 // with this one for consistent fixtures.
 const USER_ASSET_KEY =
-  'AD_4nXfIsl-erhSAeiGSkOIXhb7mnsPrFa38oCVaVUlXQYMZniGpAEuOSyLV0tFiyojQl-kGZzOCFjUTk2Y-S5_o9yqWDIX9WL8JFAuYzul_' +
-  '1PEwF5CK1vtwjhydmXIeDJ5-n_0';
+  'AD_4nXfOUdieC9bo7QjPnX1ROFNOXtJPZ9xPJAQ7qhlBzsNmw8XuSlVJi-vFeFNs9mXCoDB10pBicZwOpqO5bsEYsIPc_' +
+  'lcCDIsWfGVw18r6kSA9nygfvJsTB44V8E5OU80p5Ts';
 
 function googleDocUrl(documentId) {
   return `https://docs.google.com/document/d/${documentId}`;

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -395,10 +395,7 @@ function listFixtures() {
 
 // Main logic!
 const { values, positionals } = parseArgs({
-  options: {
-    help: { type: 'boolean', short: 'h' },
-    list: { type: 'boolean' },
-  },
+  options: { help: { type: 'boolean', short: 'h' }, list: { type: 'boolean' } },
 });
 
 if (values.help) {

--- a/scripts/download-fixtures.js
+++ b/scripts/download-fixtures.js
@@ -33,6 +33,13 @@ const FIXTURES = {
 const DOCUMENT_SLICE_CLIP_TYPE =
   'application/x-vnd.google-docs-document-slice-clip+wrapped';
 
+// Asset URLs (for images in docs) involve a user-specific key, so each time
+// we anonymously copy a fixture we get a different URL. Replace the key with
+// with this one for consistent fixtures.
+const USER_ASSET_KEY =
+  'AD_4nXfIsl-erhSAeiGSkOIXhb7mnsPrFa38oCVaVUlXQYMZniGpAEuOSyLV0tFiyojQl-kGZzOCFjUTk2Y-S5_o9yqWDIX9WL8JFAuYzul_' +
+  '1PEwF5CK1vtwjhydmXIeDJ5-n_0';
+
 function googleDocUrl(documentId) {
   return `https://docs.google.com/document/d/${documentId}`;
 }
@@ -189,10 +196,11 @@ async function getExportedGoogleDocHtml(documentId) {
 function cleanCopiedHtml(html) {
   // Google Docs adds a unique GUID to every copy operation. Overwrite it
   // so we only track meaningful changes to the content of the fixture.
-  return html.replace(
+  let clean = html.replace(
     /id="docs-internal-guid-\w{8}-\w{4}-\w{4}-\w{4}-\w{12}"/,
     `id="docs-internal-guid-dddddddd-dddd-dddd-dddd-123456789abc"`
   );
+  return cleanHtmlAssetUrls(clean);
 }
 
 /**
@@ -303,7 +311,24 @@ function cleanExportedHtml(html) {
     throw error;
   }
 
+  reformatted = cleanHtmlAssetUrls(reformatted);
+
   return reformatted;
+}
+
+/**
+ * Fix up asset URLs in copied and exported HTML. Assets (e.g. images) in docs
+ * HTML use a URL that includes a user-specific key, so may be unique for every
+ * session where we load fixtures. This replaces the unique part with something
+ * consistent.
+ * @param {string} html HTML string to clean up.
+ * @returns {string}
+ */
+function cleanHtmlAssetUrls(html) {
+  return html.replace(
+    /(<img [^>]*src="https:\/\/[^/]*googleusercontent.com\/docsz\/)[^?]+(\?key=[^"]+")/g,
+    (_, prefix, suffix) => `${prefix}${USER_ASSET_KEY}${suffix}`
+  );
 }
 
 /**

--- a/test/fixtures/non-text-between-code.copy.html
+++ b/test/fixtures/non-text-between-code.copy.html
@@ -15,7 +15,7 @@
 	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
 		<span style="font-size:11pt;font-family:'PT Mono',monospace;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
 			<span style="border:none;display:inline-block;overflow:hidden;width:559px;height:474px;">
-				<img src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXfIsl-erhSAeiGSkOIXhb7mnsPrFa38oCVaVUlXQYMZniGpAEuOSyLV0tFiyojQl-kGZzOCFjUTk2Y-S5_o9yqWDIX9WL8JFAuYzul_1PEwF5CK1vtwjhydmXIeDJ5-n_0?key=l0-uU5y2NRVMw07JkC0hlbQj" width="559" height="474" style="margin-left:0px;margin-top:0px;" />
+				<img src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXfOUdieC9bo7QjPnX1ROFNOXtJPZ9xPJAQ7qhlBzsNmw8XuSlVJi-vFeFNs9mXCoDB10pBicZwOpqO5bsEYsIPc_lcCDIsWfGVw18r6kSA9nygfvJsTB44V8E5OU80p5Ts?key=l0-uU5y2NRVMw07JkC0hlbQj" width="559" height="474" style="margin-left:0px;margin-top:0px;" />
 			</span>
 		</span>
 	</p>

--- a/test/fixtures/non-text-between-code.copy.html
+++ b/test/fixtures/non-text-between-code.copy.html
@@ -15,7 +15,7 @@
 	<p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">
 		<span style="font-size:11pt;font-family:'PT Mono',monospace;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">
 			<span style="border:none;display:inline-block;overflow:hidden;width:559px;height:474px;">
-				<img src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXfOUdieC9bo7QjPnX1ROFNOXtJPZ9xPJAQ7qhlBzsNmw8XuSlVJi-vFeFNs9mXCoDB10pBicZwOpqO5bsEYsIPc_lcCDIsWfGVw18r6kSA9nygfvJsTB44V8E5OU80p5Ts?key=l0-uU5y2NRVMw07JkC0hlbQj" width="559" height="474" style="margin-left:0px;margin-top:0px;" />
+				<img src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXfIsl-erhSAeiGSkOIXhb7mnsPrFa38oCVaVUlXQYMZniGpAEuOSyLV0tFiyojQl-kGZzOCFjUTk2Y-S5_o9yqWDIX9WL8JFAuYzul_1PEwF5CK1vtwjhydmXIeDJ5-n_0?key=l0-uU5y2NRVMw07JkC0hlbQj" width="559" height="474" style="margin-left:0px;margin-top:0px;" />
 			</span>
 		</span>
 	</p>

--- a/test/fixtures/non-text-between-code.export.html
+++ b/test/fixtures/non-text-between-code.export.html
@@ -10,15 +10,6 @@ ol{
 table td,table th{
 	padding:0
 }
-.c1{
-	color:#000000;
-	font-weight:400;
-	text-decoration:none;
-	vertical-align:baseline;
-	font-size:11pt;
-	font-family:"PT Mono";
-	font-style:normal
-}
 .c0{
 	color:#000000;
 	font-weight:400;
@@ -26,6 +17,15 @@ table td,table th{
 	vertical-align:baseline;
 	font-size:11pt;
 	font-family:"PT Sans";
+	font-style:normal
+}
+.c1{
+	color:#000000;
+	font-weight:400;
+	text-decoration:none;
+	vertical-align:baseline;
+	font-size:11pt;
+	font-family:"PT Mono";
 	font-style:normal
 }
 .c2{
@@ -157,7 +157,7 @@ h6{
 		</p>
 		<p class="c2">
 			<span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 559.00px; height: 474.00px;">
-				<img alt="" src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXey_MeSyDrcK6YXzFgmSWwLfStiaCy9h-mtF5gSTqrXA-pxxfvF2hi12wEMgDyI-JV0g-nKcWy62Mgo3bhm64EwAwaQutCUTAvLJPuY3ugC-pOrwAuozf3447S-JOUxkBg?key=l0-uU5y2NRVMw07JkC0hlbQj" style="width: 559.00px; height: 474.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title="">
+				<img alt="" src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXdJZKwZg6bf4_2DBQXbdKvJLjq4YtpxG4YSMvBTSTH9Y_0aws207NuCifaNBVY7eiZKpFrkOI-Rm9aqZXK2iTqJ6POEKznGAZmTQuVHDnqzq2LkTIcoi-ql6-Znq-2o1SY?key=l0-uU5y2NRVMw07JkC0hlbQj" style="width: 559.00px; height: 474.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title="">
 			</span>
 		</p>
 		<p class="c2 c3">

--- a/test/fixtures/non-text-between-code.export.html
+++ b/test/fixtures/non-text-between-code.export.html
@@ -157,7 +157,7 @@ h6{
 		</p>
 		<p class="c2">
 			<span style="overflow: hidden; display: inline-block; margin: 0.00px 0.00px; border: 0.00px solid #000000; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px); width: 559.00px; height: 474.00px;">
-				<img alt="" src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXdJZKwZg6bf4_2DBQXbdKvJLjq4YtpxG4YSMvBTSTH9Y_0aws207NuCifaNBVY7eiZKpFrkOI-Rm9aqZXK2iTqJ6POEKznGAZmTQuVHDnqzq2LkTIcoi-ql6-Znq-2o1SY?key=l0-uU5y2NRVMw07JkC0hlbQj" style="width: 559.00px; height: 474.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title="">
+				<img alt="" src="https://lh7-rt.googleusercontent.com/docsz/AD_4nXffzJvyPiYAwiFsb1cKSX0fjeEhXPfUi90gJCznABE9AvwNq5VvXXKWavuLVj-opOYIsXBI2qOZkb3TUVMIO78zOThKhF-5QXUqOtCFUnLBY4_MjMkwv-6q1aBUC3dNh9k?key=l0-uU5y2NRVMw07JkC0hlbQj" style="width: 559.00px; height: 474.00px; margin-left: 0.00px; margin-top: 0.00px; transform: rotate(0.00rad) translateZ(0px); -webkit-transform: rotate(0.00rad) translateZ(0px);" title="">
 			</span>
 		</p>
 		<p class="c2 c3">


### PR DESCRIPTION
The asset URLs in the Google Docs HTML (both copied and exported) include a unique-to-the-user key (presumably anonymized/hashed in some way). This meant each time we tried to refresh fixtures with images, we'd get a different result (since we are not logged in, we are a different user every time). This replaces the unique part of the asset URLs with a consistent key so our fixtures aren't pointlessly changing.

Obviates #284.