### PR TITLE
Fix Safari issues in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
   unit-tests:
     # Use MacOS so we can test in Safari.
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
 
   e2e-tests:
     # Use MacOS so we can test in Safari.
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -12929,10 +12929,11 @@
       "dev": true
     },
     "node_modules/safaridriver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
-      "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -25055,9 +25056,9 @@
       }
     },
     "safaridriver": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.0.tgz",
-      "integrity": "sha512-J92IFbskyo7OYB3Dt4aTdyhag1GlInrfbPCmMteb7aBK7PwlnGz1HI0+oyNN97j7pV9DqUAVoVgkNRMrfY47mQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
       "dev": true
     },
     "safe-buffer": {


### PR DESCRIPTION
Some change to the `macos-latest` runner between last week and now is causing Safari tests to fail to be able to focus or send input to fields on the page.