### PR TITLE
Add cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'monthly'
+    cooldown:
+      default-days: 7
     versioning-strategy: widen
     groups:
       # WebdriverIO frequently makes cross-ecosystem changes


### PR DESCRIPTION
Pretty much what it says on the tin! Just a basic fix to make Dependabot updates less likely to introduce problems.